### PR TITLE
176472115 habitat notebook

### DIFF
--- a/src/assets/check-icon.svg
+++ b/src/assets/check-icon.svg
@@ -1,0 +1,4 @@
+<svg height="12" width="12" stroke="white">
+  <line x1="1" y1="6" x2="6" y2="10" style="stroke-width:3" />
+  <line x1="10" y1="1" x2="6" y2="10" style="stroke-width:3" />
+</svg>

--- a/src/assets/check-icon.svg
+++ b/src/assets/check-icon.svg
@@ -1,4 +1,3 @@
-<svg height="12" width="12" stroke="white">
-  <line x1="1" y1="6" x2="6" y2="10" style="stroke-width:3" />
-  <line x1="10" y1="1" x2="6" y2="10" style="stroke-width:3" />
+<svg height="12" width="12" stroke="white" stroke-width="2.5">
+  <polyline points="1,6 6,10 10,1" fill="none" />
 </svg>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -152,7 +152,6 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
 
   const [habitatSelectedFeatures, setHabitatSelectedFeatures] = useState(Array(kTotalHabitatFeatures).fill(false));
   const handleHabitatSelectFeature = (index: number, value: boolean) => {
-    console.log(index, value);
     const newSelectedFeatures = habitatSelectedFeatures.map((featureSelection, i) => i === index ? value : featureSelection);
     setHabitatSelectedFeatures(newSelectedFeatures);
   };

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -10,7 +10,7 @@ import { Notebook } from "./notebook/notebook";
 import { Tray } from "./simulation/tray";
 import { Model } from "../model";
 import { LeafEatersAmountType, Environment, Environments, EnvironmentType, getSunnyDayLogLabel, AlgaeEatersAmountType,
-         LeafDecompositionType, FishAmountType, LeafPackStates, TrayAnimal } from "../utils/sim-utils";
+         LeafDecompositionType, FishAmountType, LeafPackStates, TrayAnimal, kTotalHabitatFeatures } from "../utils/sim-utils";
 import t from "../utils/translation/translate";
 
 import "./app.scss";
@@ -150,6 +150,13 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
     rewindSimulation();
   };
 
+  const [habitatSelectedFeatures, setHabitatSelectedFeatures] = useState(Array(kTotalHabitatFeatures).fill(false));
+  const handleHabitatSelectFeature = (index: number, value: boolean) => {
+    console.log(index, value);
+    const newSelectedFeatures = habitatSelectedFeatures.map((featureSelection, i) => i === index ? value : featureSelection);
+    setHabitatSelectedFeatures(newSelectedFeatures);
+  };
+
   return (
     <div className="app" data-testid="app">
       <div className="content">
@@ -183,6 +190,9 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
           </MainViewWrapper>
           <Notebook
             trayAnimals={trayAnimals}
+            environment={environment}
+            featureSelections={habitatSelectedFeatures}
+            onSelectFeature={handleHabitatSelectFeature}
             isRunning={isRunning}
           />
         </div>

--- a/src/components/notebook/habitat-panel.scss
+++ b/src/components/notebook/habitat-panel.scss
@@ -43,7 +43,7 @@
       .feature-row {
         display: flex;
         flex-direction: row;
-        margin: 5px 5px 5px 0;
+        margin: 11px 5px 5px 0;
         font-size: 14px;
         font-weight: normal;
 

--- a/src/components/notebook/habitat-panel.scss
+++ b/src/components/notebook/habitat-panel.scss
@@ -2,11 +2,86 @@
 
 .habitat-panel {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
   width: 438px;
   height: 304px;
   border-radius: 0 0 10px 10px;
   border: solid 1px $gray-dark;
   border-top: none;
+  font-size: 14px;
+  font-weight: bold;
+
+  .categories{
+    display: flex;
+    flex-direction: row;
+    margin-top: 15px;
+
+    .category {
+      height: 219px;
+      border-right: solid 1px $gray-dark25;
+      padding-right: 9px;
+      margin-right: 9px;
+      margin-bottom: 15px;
+      width: 124px;
+      &:first-child {
+        margin-left: 14px;
+      }
+      &:last-child {
+        border-right: none;
+      }
+
+      .header {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background-color: $habitat-orange-dark1;
+        width: 124px;
+        height: 24px;
+      }
+
+      .feature-row {
+        display: flex;
+        flex-direction: row;
+        margin: 5px 5px 5px 0;
+        font-size: 14px;
+        font-weight: normal;
+
+        .checkbox {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          height: 18px;
+          width: 18px;
+          border: solid 2px black;
+          background-color: white;
+          box-sizing: border-box;
+          margin-right: 8px;
+          padding: 0;
+
+          &:hover {
+            background-color: $habitat-green-check-hover;
+          }
+          &:active, &.selected {
+            background-color: $habitat-green-check;
+            border: none;
+          }
+
+          .check {
+            height: 13px;
+            width: 13px;
+          }
+
+        }
+      }
+
+      img {
+        border-radius: 5px;
+        border: solid 1px $gray-dark;
+        margin-top: 10px;
+      }
+
+    }
+
+  }
 }

--- a/src/components/notebook/habitat-panel.scss
+++ b/src/components/notebook/habitat-panel.scss
@@ -58,6 +58,7 @@
           box-sizing: border-box;
           margin-right: 8px;
           padding: 0;
+          flex-shrink: 0;
           cursor: pointer;
 
           &:hover {

--- a/src/components/notebook/habitat-panel.scss
+++ b/src/components/notebook/habitat-panel.scss
@@ -58,6 +58,7 @@
           box-sizing: border-box;
           margin-right: 8px;
           padding: 0;
+          cursor: pointer;
 
           &:hover {
             background-color: $habitat-green-check-hover;
@@ -65,6 +66,14 @@
           &:active, &.selected {
             background-color: $habitat-green-check;
             border: none;
+          }
+
+          &.selected:hover {
+            background-color: $habitat-green-check-hover;
+          }
+          &.selected:active {
+            border: solid 2px black;
+            background-color: white;
           }
 
           .check {

--- a/src/components/notebook/habitat-panel.tsx
+++ b/src/components/notebook/habitat-panel.tsx
@@ -1,15 +1,63 @@
-import React from "react";
+import React, { useState } from "react";
+import { SectionButtons } from "./section-buttons";
+import { EnvironmentType, habitatCategories, Environments } from "../../utils/sim-utils";
+import CheckIcon from "../../assets/check-icon.svg";
 
 import "./habitat-panel.scss";
 
+const kCategoriesPerSection = 3;
+
 interface IProps {
+  environment: EnvironmentType;
+  featureSelections: boolean[];
+  onSelectFeature: (index: number, selected: boolean) => void;
   isRunning: boolean;
 }
 
 export const HabitatPanel: React.FC<IProps> = (props) => {
+  const { environment, featureSelections, onSelectFeature } = props;
+  const [currentSection, setCurrentSection] = useState(0);
+  const numSections = Math.ceil(habitatCategories.length / kCategoriesPerSection);
+  const environmentImage = Environments.find((env) => env.type === environment)?.sketchImage;
+
+  const featureOrder: string[] = [];
+  habitatCategories.forEach((hCat) => {
+    hCat.features?.forEach((feat) => {
+      featureOrder.push(feat);
+    });
+  });
+
   return (
     <div className="habitat-panel">
-      Habitat Panel
+      <div className="categories">
+        {habitatCategories.map((category, cIndex) =>
+          cIndex >= kCategoriesPerSection * currentSection &&
+          cIndex < kCategoriesPerSection * currentSection + kCategoriesPerSection &&
+          <div key={`habitat-category-${cIndex}`} className="category">
+            <div className="header">{category.title}</div>
+            { category.features
+              ? category.features.map((feature, fIndex) =>
+                  <div className="feature-row" key={`feature-row-${fIndex}`}>
+                    <button
+                      className={`checkbox ${featureSelections[featureOrder.findIndex((f) => f === feature)] ? "selected" : ""}`}
+                      onClick={() => onSelectFeature(featureOrder.findIndex((f) => f === feature),
+                        !featureSelections[featureOrder.findIndex((f) => f === feature)])}
+                    >
+                      <CheckIcon className="check" />
+                    </button>
+                    <div key={`feature-${fIndex}`}>{feature}</div>
+                  </div>
+                )
+              : <img src={environmentImage} />
+            }
+          </div>
+        )}
+      </div>
+      <SectionButtons
+        currentSection={currentSection}
+        totalSections={numSections}
+        onSelectSection={setCurrentSection}
+      />
     </div>
   );
 };

--- a/src/components/notebook/notebook.scss
+++ b/src/components/notebook/notebook.scss
@@ -57,6 +57,9 @@
     &:hover {
       background-color: $gray-dark5;
     }
+    &:active {
+      background-color: white;
+    }
   }
 
   ul {

--- a/src/components/notebook/notebook.tsx
+++ b/src/components/notebook/notebook.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
-import { TrayAnimal } from "../../utils/sim-utils";
+import { EnvironmentType, TrayAnimal } from "../../utils/sim-utils";
 import { HabitatPanel } from "./habitat-panel";
 import { ChemistryPanel } from "./chemistry-panel";
 import { MacroPanel } from "./macro-panel";
@@ -13,11 +13,14 @@ import "./notebook.scss";
 
 interface IProps {
   trayAnimals: TrayAnimal[];
+  environment: EnvironmentType;
+  featureSelections: boolean[];
+  onSelectFeature: (index: number, selected: boolean) => void;
   isRunning: boolean;
 }
 
 export const Notebook: React.FC<IProps> = (props) => {
-  const { isRunning } = props;
+  const { environment, featureSelections, onSelectFeature, isRunning } = props;
   return (
     <div className="notebook" data-testid="notebook">
       <Tabs>
@@ -29,6 +32,9 @@ export const Notebook: React.FC<IProps> = (props) => {
 
         <TabPanel>
           <HabitatPanel
+            environment={environment}
+            featureSelections={featureSelections}
+            onSelectFeature={onSelectFeature}
             isRunning={isRunning}
           />
         </TabPanel>

--- a/src/components/notebook/section-buttons.scss
+++ b/src/components/notebook/section-buttons.scss
@@ -10,7 +10,7 @@
   background-color: white;
 
   .section-button {
-    font-family: 'Lato', sans-serif;
+    font-family: "Lato", sans-serif;
     font-size: 18px;
     font-weight: bold;
     background-color: white;

--- a/src/components/notebook/section-buttons.scss
+++ b/src/components/notebook/section-buttons.scss
@@ -10,7 +10,7 @@
   background-color: white;
 
   .section-button {
-    font-family: Lato;
+    font-family: 'Lato', sans-serif;
     font-size: 18px;
     font-weight: bold;
     background-color: white;

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -17,6 +17,10 @@ $habitat-orange: #F8EFE1;
 $macro-green: #EDF7E1;
 $chemistry-blue: #E4F5F8;
 
+$habitat-orange-dark1: #f4e4cb;
+$habitat-green-check: #5DA400;
+$habitat-green-check-hover: #AED27F;
+
 $thumbnail-border-radius: 8px;
 $component-border-radius: 10px;
 $control-panel-height: 81px;

--- a/src/index.scss
+++ b/src/index.scss
@@ -4,6 +4,6 @@ html, body {
 }
 
 body {
-  font-family: 'Lato', sans-serif;
+  font-family: "Lato", sans-serif;
   user-select: none;
 }

--- a/src/utils/sim-utils.ts
+++ b/src/utils/sim-utils.ts
@@ -470,16 +470,20 @@ export enum HabitatCategoryType {
   other = "other",
 }
 
-export interface HabitatSection {
+export interface HabitatCategory {
   type: HabitatCategoryType;
-  categories?: string[];
+  title: string;
+  features?: string[];
 }
 
-export const habitatSections = [
-  { type: HabitatCategoryType.sketch },
-  { type: HabitatCategoryType.streamHabitats, categories: [t("HABITAT.POOLS"), t("HABITAT.RIFFLES"), t("HABITAT.RUNS")] },
-  { type: HabitatCategoryType.banks, categories: [t("HABITAT.MANYTREES"), t("HABITAT.SOMETREES"), t("HABITAT.NOTREES"), t("HABITAT.GRASSONLY"), t("HABITAT.PAVEMENT")] },
-  { type: HabitatCategoryType.inStream, categories: [t("HABITAT.LEAVES"), t("HABITAT.COBBLES"), t("HABITAT.WOODYDEBRIS"), t("HABITAT.PLANTROOTS")] },
-  { type: HabitatCategoryType.algae, categories: [t("HABITAT.LIGHTCOVER"), t("HABITAT.THICKCOVER"), t("HABITAT.THICKCOVERCLUMPS")] },
-  { type: HabitatCategoryType.other, categories: [t("HABITAT.FISH"), t("HABITAT.OTTERS"), t("HABITAT.TRASH"), t("HABITAT.PIPES")] },
+export const habitatCategories = [
+  { type: HabitatCategoryType.sketch, title: t("HABITAT.SKETCH")},
+  { type: HabitatCategoryType.streamHabitats, title: t("HABITAT.STREAMHABITATS"), features: [t("HABITAT.POOLS"), t("HABITAT.RIFFLES"), t("HABITAT.RUNS")] },
+  { type: HabitatCategoryType.banks, title: t("HABITAT.BANKS"), features: [t("HABITAT.MANYTREES"), t("HABITAT.SOMETREES"), t("HABITAT.NOTREES"), t("HABITAT.GRASSONLY"), t("HABITAT.PAVEMENT")] },
+  { type: HabitatCategoryType.inStream, title: t("HABITAT.INSTREAM"), features: [t("HABITAT.LEAVES"), t("HABITAT.COBBLES"), t("HABITAT.WOODYDEBRIS"), t("HABITAT.PLANTROOTS")] },
+  { type: HabitatCategoryType.algae, title: t("HABITAT.ALGAE"), features: [t("HABITAT.LIGHTCOVER"), t("HABITAT.THICKCOVER"), t("HABITAT.THICKCOVERCLUMPS")] },
+  { type: HabitatCategoryType.other, title: t("HABITAT.OTHER"), features: [t("HABITAT.FISH"), t("HABITAT.OTTERS"), t("HABITAT.TRASH"), t("HABITAT.PIPES")] },
 ];
+
+// TODO: get this from habitatCategories
+export const kTotalHabitatFeatures = 19;

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -24,6 +24,13 @@
   "SENSITIVITY.2": "Somewhat Sensitive",
   "SENSITIVITY.3": "Tolerant",
 
+  "HABITAT.SKETCH": "Sketch",
+  "HABITAT.STREAMHABITATS": "Stream Habitats",
+  "HABITAT.BANKS": "Banks",
+  "HABITAT.INSTREAM": "In Stream",
+  "HABITAT.ALGAE": "Algae",
+  "HABITAT.OTHER": "Other",
+
   "HABITAT.POOLS": "Pools",
   "HABITAT.RIFFLES": "Riffles",
   "HABITAT.RUNS": "Runs",

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -24,6 +24,13 @@
   "SENSITIVITY.2": "Somewhat Sensitive",
   "SENSITIVITY.3": "Tolerant",
 
+  "HABITAT.SKETCH": "Sketch",
+  "HABITAT.STREAMHABITATS": "Stream Habitats",
+  "HABITAT.BANKS": "Banks",
+  "HABITAT.INSTREAM": "In Stream",
+  "HABITAT.ALGAE": "Algae",
+  "HABITAT.OTHER": "Other",
+
   "HABITAT.POOLS": "Pools",
   "HABITAT.RIFFLES": "Riffles",
   "HABITAT.RUNS": "Runs",


### PR DESCRIPTION
This PR adds the habitat notebook page which is displayed when the habitat tab is clicked.  Changes include:
- update HabitatPanel component to display proper habitat categories and checkboxes and display section buttons to move between habitat sections.
- add state to main App component to keep track of checkboxes
- update text translations (note: final Spanish translation will be done in future work)
- add SVG icons

![image](https://user-images.githubusercontent.com/5126913/107276951-9a8ac380-6a08-11eb-83d8-ce6cde0688bc.png)
