### PR TITLE
176917444 button updates

### DIFF
--- a/src/assets/home-icon.svg
+++ b/src/assets/home-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#000000">
+    <path fill-rule="nonzero" d="M10 20L10 14 14 14 14 20 19 20 19 12 22 12 12 3 2 12 5 12 5 20z" transform="translate(-593 -681) translate(110 260) translate(432 120) translate(41 291) translate(7 7) translate(3 3)"/>
+</svg>

--- a/src/components/notebook/chemistry-panel.scss
+++ b/src/components/notebook/chemistry-panel.scss
@@ -2,11 +2,20 @@
 
 .chemistry-panel {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
   width: 438px;
   height: 304px;
   border-radius: 0 0 10px 10px;
   border: solid 1px $gray-dark;
   border-top: none;
+  font-size: 14px;
+  font-weight: bold;
+
+  .section-content {
+    display: flex;
+    flex-direction: row;
+    margin-top: 15px;
+    height: 237px;
+  }
 }

--- a/src/components/notebook/chemistry-panel.tsx
+++ b/src/components/notebook/chemistry-panel.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import { SectionButtons } from "./section-buttons";
 
 import "./chemistry-panel.scss";
 
@@ -7,9 +8,20 @@ interface IProps {
 }
 
 export const ChemistryPanel: React.FC<IProps> = (props) => {
+  const [currentSection, setCurrentSection] = useState(0);
+  const numSections = 7; // TODO: derive this from export in util module
+
   return (
     <div className="chemistry-panel">
-      Chemistry Panel
+      <div className="section-content">
+        Chemistry Panel
+      </div>
+      <SectionButtons
+        currentSection={currentSection}
+        totalSections={numSections}
+        onSelectSection={setCurrentSection}
+        showHomeButton={true}
+      />
     </div>
   );
 };

--- a/src/components/notebook/habitat-panel.scss
+++ b/src/components/notebook/habitat-panel.scss
@@ -36,7 +36,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        background-color: $habitat-orange-dark1;
+        background-color: $habitat-brown-dark1;
         width: 124px;
         height: 24px;
       }

--- a/src/components/notebook/notebook.scss
+++ b/src/components/notebook/notebook.scss
@@ -50,7 +50,7 @@
 
     &.habitat {
       &.react-tabs__tab--selected .inner {
-        background-color: $habitat-orange;
+        background-color: $habitat-brown;
       }
     }
 

--- a/src/components/notebook/section-buttons.scss
+++ b/src/components/notebook/section-buttons.scss
@@ -10,6 +10,9 @@
   background-color: white;
 
   .section-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     font-family: "Lato", sans-serif;
     font-size: 18px;
     font-weight: bold;
@@ -29,12 +32,20 @@
     &:active {
       background-color: black;
       color: white;
+
+      .home-icon {
+        fill: white;
+      }
     }
 
     &.selected {
       background-color: black;
       color: white;
       pointer-events: none;
+
+      .home-icon {
+        fill: white;
+      }
     }
 
     &:first-child {
@@ -43,5 +54,33 @@
     &:last-child {
       margin-right: 5px;
     }
+
+  }
+}
+
+.habitat-panel .section-buttons .section-button {
+  &:hover {
+    background-color: $habitat-brown-dark2;
+  }
+  &.selected, &:active {
+    background-color: $habitat-brown-dark3;
+  }
+}
+
+.macro-panel .section-buttons .section-button {
+  &:hover {
+    background-color: $macro-green-dark2;
+  }
+  &.selected, &:active {
+    background-color: $macro-green-dark3;
+  }
+}
+
+.chemistry-panel .section-buttons .section-button {
+  &:hover {
+    background-color: $chemistry-blue-dark2;
+  }
+  &.selected, &:active {
+    background-color: $chemistry-blue-dark3;
   }
 }

--- a/src/components/notebook/section-buttons.tsx
+++ b/src/components/notebook/section-buttons.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import HomeIcon from "../../assets/home-icon.svg";
 
 import "./section-buttons.scss";
 
@@ -6,10 +7,11 @@ interface IProps {
   currentSection: number;
   totalSections: number;
   onSelectSection: (index: number) => void;
+  showHomeButton?: boolean;
 }
 
 export const SectionButtons: React.FC<IProps> = (props) => {
-  const { currentSection, totalSections, onSelectSection } = props;
+  const { currentSection, totalSections, onSelectSection, showHomeButton } = props;
   const pages = Array(totalSections).fill("section");
   return (
     <div className="section-buttons">
@@ -19,7 +21,10 @@ export const SectionButtons: React.FC<IProps> = (props) => {
           className={`section-button ${currentSection === index ? "selected" : ""}`}
           onClick={() => onSelectSection(index)}
         >
-          {index + 1}
+          {showHomeButton
+          ? index === 0 ? <HomeIcon className="home-icon" /> : index
+          : index + 1
+          }
         </button>
       )}
     </div>

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -13,13 +13,21 @@ $gray-dark5: #f5f5f5;
 $gray-dark10: #eaeaea;
 $gray-dark25: #cccccc;
 
-$habitat-orange: #F8EFE1;
-$macro-green: #EDF7E1;
+
 $chemistry-blue: #E4F5F8;
+$chemistry-blue-dark2: #a3dce7;
+$chemistry-blue-dark3: #0b8096;
+
+$macro-green: #EDF7E1;
 $macro-green-dark1: #e1f2cb;
+$macro-green-dark2: #c2e397;
+$macro-green-dark3: #50830d;
 $macro-score-pink: #f8b8c8;
 
-$habitat-orange-dark1: #f4e4cb;
+$habitat-brown: #F8EFE1;
+$habitat-brown-dark1: #f4e4cb;
+$habitat-brown-dark2: #e7c997;
+$habitat-brown-dark3: #9f680d;
 $habitat-green-check: #5DA400;
 $habitat-green-check-hover: #AED27F;
 


### PR DESCRIPTION
This PR updates the notebook section buttons in anticipation of their use in the chemistry lab page while also updating button colors to adhere to the latest UI spec.  Changes include:
- add optional home button that can be shown before section 1
- update button colors - the habitat, macro, and chem pages all have different button colors

NOTE: the final chem lab page will pull the number of buttons from an export in a util module - I'm temporarily using a constant which will be replaced in a subsequent PR.

![image](https://user-images.githubusercontent.com/5126913/108140475-fd1e3800-7076-11eb-87ee-e1b095e434b5.png)

![buttons](https://user-images.githubusercontent.com/5126913/108140488-014a5580-7077-11eb-96b0-f53330abc12b.gif)
