### PR TITLE
Refactor from sim-utils into macro-utils, make chem-utils stub

### DIFF
--- a/src/components/notebook/macro-rating.tsx
+++ b/src/components/notebook/macro-rating.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import IconArrow from "../../assets/scale-pointer.svg";
 import t from "../../utils/translation/translate";
-import { PTIRatingLevels, PTIRatingLevel } from "../../utils/sim-utils";
+import { PTIRatingLevels, PTIRatingLevel } from "../../utils/macro-utils";
 
 import "./macro-rating.scss";
 

--- a/src/components/notebook/macro-score.tsx
+++ b/src/components/notebook/macro-score.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import t from "../../utils/translation/translate";
-import { PTIRatingLevels } from "../../utils/sim-utils";
+import { PTIRatingLevels } from "../../utils/macro-utils";
 
 import "./macro-score.scss";
 

--- a/src/components/notebook/macro-summation.tsx
+++ b/src/components/notebook/macro-summation.tsx
@@ -4,7 +4,8 @@ import PTIIcon from "../../assets/pti-icon.svg";
 import { MacroSensitivities } from "./macro-sensitivities";
 import { MacroScore } from "./macro-score";
 import { MacroRating } from "./macro-rating";
-import { Sensitivities, SensitivityType, PTIRatingLevels, TrayObject, Animals } from "../../utils/sim-utils";
+import { SensitivityType, TrayObject, Animals } from "../../utils/sim-utils";
+import { getPTIScore, getPTIRatingIndex } from "../../utils/macro-utils";
 
 import "./macro-summation.scss";
 
@@ -25,17 +26,8 @@ export const MacroSummation: React.FC<IProps> = (props) => {
     }
   });
 
-  let score = 0;
-  Sensitivities.forEach((s, i) => {
-    score = score + taxaSensitivities[s.type] * (Sensitivities.length - i);
-  });
-
-  let ratingIndex = 0;
-  for (let i = PTIRatingLevels.length - 1; i >= 0; i--) {
-    if (score >= PTIRatingLevels[i].min) {
-      ratingIndex = i;
-    }
-  }
+  const score = getPTIScore(trayObjects);
+  const ratingIndex = getPTIRatingIndex(score);
 
   return (
     <div className="macro-summation">

--- a/src/utils/chem-utils.ts
+++ b/src/utils/chem-utils.ts
@@ -1,0 +1,1 @@
+// TODO: add chem utils exports

--- a/src/utils/macro-utils.ts
+++ b/src/utils/macro-utils.ts
@@ -1,0 +1,44 @@
+import t from "./translation/translate";
+import { Sensitivities, SensitivityType, TrayObject, Animals } from "../utils/sim-utils";
+
+// PTI
+export interface PTIRatingLevel {
+  color: string;
+  label: string;
+  range: string;
+  min: number;
+}
+
+export const PTIRatingLevels: PTIRatingLevel[] = [
+  {color: "#a4f9be", label: t("PTI.RATING.LEVEL0.LABEL"), range: t("PTI.RATING.LEVEL0.RANGE"), min: 24},
+  {color: "#94e5ff", label: t("PTI.RATING.LEVEL1.LABEL"), range: t("PTI.RATING.LEVEL1.RANGE"), min: 17},
+  {color: "#cccccc", label: t("PTI.RATING.LEVEL2.LABEL"), range: t("PTI.RATING.LEVEL2.RANGE"), min: 11},
+  {color: "#ffacac", label: t("PTI.RATING.LEVEL3.LABEL"), range: t("PTI.RATING.LEVEL3.RANGE"), min: 0}
+];
+
+export const getPTIScore = (trayObjects: TrayObject[]) => {
+  const taxaSensitivities: Record<SensitivityType, number> = {sensitive: 0, somewhatSensitive: 0, tolerant: 0};
+  trayObjects.forEach((obj, i) => {
+    if (obj.count > 0 && obj.collected) {
+      const animal = Animals.find((a) => a.type === obj.type);
+      if (animal) {
+        taxaSensitivities[animal.sensitivity]++;
+      }
+    }
+  });
+  let score = 0;
+  Sensitivities.forEach((s, i) => {
+    score = score + taxaSensitivities[s.type] * (Sensitivities.length - i);
+  });
+  return score;
+}
+
+export const getPTIRatingIndex = (score: number) => {
+  let ratingIndex = 0;
+  for (let i = PTIRatingLevels.length - 1; i >= 0; i--) {
+    if (score >= PTIRatingLevels[i].min) {
+      ratingIndex = i;
+    }
+  }
+  return ratingIndex;
+}

--- a/src/utils/macro-utils.ts
+++ b/src/utils/macro-utils.ts
@@ -31,7 +31,7 @@ export const getPTIScore = (trayObjects: TrayObject[]) => {
     score = score + taxaSensitivities[s.type] * (Sensitivities.length - i);
   });
   return score;
-}
+};
 
 export const getPTIRatingIndex = (score: number) => {
   let ratingIndex = 0;
@@ -41,4 +41,4 @@ export const getPTIRatingIndex = (score: number) => {
     }
   }
   return ratingIndex;
-}
+};

--- a/src/utils/sim-utils.ts
+++ b/src/utils/sim-utils.ts
@@ -619,18 +619,3 @@ export const draggableLeafTypes = [
   LeafType.oak0, LeafType.oak1, LeafType.oak2, LeafType.oak3, LeafType.oak4, LeafType.oak5, LeafType.oak6,
   LeafType.maple0, LeafType.maple1, LeafType.maple2, LeafType.maple3, LeafType.maple4, LeafType.maple5, LeafType.maple6
 ];
-
-// PTI
-export interface PTIRatingLevel {
-  color: string;
-  label: string;
-  range: string;
-  min: number;
-}
-
-export const PTIRatingLevels: PTIRatingLevel[] = [
-  {color: "#a4f9be", label: t("PTI.RATING.LEVEL0.LABEL"), range: t("PTI.RATING.LEVEL0.RANGE"), min: 24},
-  {color: "#94e5ff", label: t("PTI.RATING.LEVEL1.LABEL"), range: t("PTI.RATING.LEVEL1.RANGE"), min: 17},
-  {color: "#cccccc", label: t("PTI.RATING.LEVEL2.LABEL"), range: t("PTI.RATING.LEVEL2.RANGE"), min: 11},
-  {color: "#ffacac", label: t("PTI.RATING.LEVEL3.LABEL"), range: t("PTI.RATING.LEVEL3.RANGE"), min: 0}
-];


### PR DESCRIPTION
Minor refactor to make things easier moving forward:
- move PTI related exports and PTI score and rating calculations into `macro-utils.ts`
- make stub `chem-utils.ts` for future content

NOTE: there is some wiggle room as to where some of these exports belong, but I think putting some similar exports into their own module will be useful (like all of the PTI calculations that are used on the macro notebook page).  We could also call this simply `pti-utils.ts` and use it only for pollution tolerance index (PTI) related content.