### PR TITLE
Add alt tags, aria labels, and default language

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -13,7 +13,7 @@ import { Tray } from "./simulation/tray";
 import { ModalDialog } from "./modal-dialog";
 import Modal from "react-modal";
 import { Model } from "../model";
-import { LeafEatersAmountType, Environment, Environments, EnvironmentType, getSunnyDayLogLabel, AlgaeEatersAmountType,
+import { LeafEatersAmountType, EnvironmentType, getSunnyDayLogLabel, AlgaeEatersAmountType,
          LeafDecompositionType, FishAmountType, LeafPackStates, TrayObject, AnimalInstance, Animals, kTraySpawnPadding,
          kMinTrayX, kMaxTrayX, kMinTrayY, kMaxTrayY, kMinLeaves, kMaxLeaves, TrayType, Leaves, draggableAnimalTypes
        } from "../utils/sim-utils";
@@ -212,8 +212,6 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
     setInputState({environment: value});
   };
 
-  const currentEnvironment = Environments.find((env: Environment) => env.type === environment);
-  const backgroundImage = currentEnvironment?.backgroundImage;
   const leafPackState = LeafPackStates.find((ls) => ls.leafDecomposition === leafDecomposition) || LeafPackStates[0];
 
   const [trayObjects, setTrayObjects] = useState<TrayObject[]>([]);
@@ -307,7 +305,6 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
               savedBgColor={kSavedBgColor}
             >
               <SimulationView
-                backgroundImage={backgroundImage}
                 environment={environment}
                 leafPackState={leafPackState}
                 fish={fish}

--- a/src/components/notebook/habitat-panel.tsx
+++ b/src/components/notebook/habitat-panel.tsx
@@ -20,6 +20,7 @@ export const HabitatPanel: React.FC<IProps> = (props) => {
   const [currentSection, setCurrentSection] = useState(0);
   const numSections = Math.ceil(habitatCategories.length / kCategoriesPerSection);
   const environmentImage = Environments.find((env) => env.type === environment)?.sketchImage;
+  const environmentImageAltText = Environments.find((env) => env.type === environment)?.sketchImageAltText;
 
   const featureOrder: string[] = [];
   habitatCategories.forEach((hCat) => {
@@ -42,13 +43,14 @@ export const HabitatPanel: React.FC<IProps> = (props) => {
                     <button
                       className={`checkbox ${featureSelections[feature] ? "selected" : ""}`}
                       onClick={() => onSelectFeature(feature, !featureSelections[feature])}
+                      aria-label={habitatFeatures.find((f) => f.type === feature)?.label}
                     >
                       <CheckIcon />
                     </button>
                     <div key={`feature-${fIndex}`}>{habitatFeatures.find((f) => f.type === feature)?.label}</div>
                   </div>
                 )
-              : <img src={environmentImage} />
+              : <img src={environmentImage} alt={environmentImageAltText} />
             }
           </div>
         )}

--- a/src/components/simulation/leaf-pack.tsx
+++ b/src/components/simulation/leaf-pack.tsx
@@ -20,6 +20,7 @@ export const LeafPack: React.FC<IProps> = (props) => {
           src={leafState.image}
           key={`leaf-${index}`}
           className={`${leafState.leafDecomposition === leafDecomposition ? "selected" : ""} ${isRunning ? "slow-animate" : ""}`}
+          alt={leafState.altText}
         />
       )}
     </div>

--- a/src/components/simulation/simulation-animation.tsx
+++ b/src/components/simulation/simulation-animation.tsx
@@ -26,6 +26,7 @@ export const SimulationAnimation: React.FC<IProps> = (props) => {
       src={animation.frames[currentFrame]}
       className={"simulation-animation"}
       style={{ top: animation.top, left: animation.left, transform: transformation }}
+      alt={animation.altText}
     />
   );
 };

--- a/src/components/simulation/simulation-view.tsx
+++ b/src/components/simulation/simulation-view.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { LeafPack } from "./leaf-pack";
 import { SimulationAnimation } from "./simulation-animation";
-import { EnvironmentType, LeafPackConfigurations, LeafPackState, SimAnimals, SimAnimation, FishAmountType, SimAnimationType
-       } from "../../utils/sim-utils";
+import { EnvironmentType, LeafPackConfigurations, LeafPackState, SimAnimals, SimAnimation, FishAmountType, SimAnimationType,
+         Environment, Environments } from "../../utils/sim-utils";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 
 import "./simulation-view.scss";
@@ -13,7 +13,6 @@ const kFishCountLots = 5;
 const kSimulationOneWeekPeriodInMilliseconds = 3667;
 
 interface IProps {
-  backgroundImage: any;
   environment: EnvironmentType;
   leafPackState: LeafPackState;
   fish: FishAmountType;
@@ -23,7 +22,11 @@ interface IProps {
 }
 
 export const SimulationView: React.FC<IProps> = (props) => {
-  const { backgroundImage, environment, leafPackState, fish, isRunning, isFinished, onShowTray } = props;
+  const { environment, leafPackState, fish, isRunning, isFinished, onShowTray } = props;
+  const currentEnvironment = Environments.find((env: Environment) => env.type === environment);
+  const backgroundImage = currentEnvironment?.backgroundImage;
+  const backgroundImageAltText = currentEnvironment?.backgroundImageAltText;
+
   const leafPackConfiguration = LeafPackConfigurations.find((lp) => lp.environment === environment);
   const fishCount = fish === FishAmountType.few
     ? kFishCountFew
@@ -38,7 +41,8 @@ export const SimulationView: React.FC<IProps> = (props) => {
           top: layout.top,
           xScale: layout.xScale,
           yScale: layout.yScale,
-          rotation: layout.rotation
+          rotation: layout.rotation,
+          altText: fishAnimationConfig.altText
         }
       );
     }
@@ -46,7 +50,7 @@ export const SimulationView: React.FC<IProps> = (props) => {
 
   return (
     <div className="simulation-view" data-testid="simulation-view">
-      <img src={backgroundImage} className="background" />
+      <img src={backgroundImage} className="background" alt={backgroundImageAltText} />
       <LeafPack
         leafDecomposition={leafPackState.leafDecomposition}
         left={leafPackConfiguration?.left}

--- a/src/components/simulation/tray-image.tsx
+++ b/src/components/simulation/tray-image.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TrayType, TrayObject, LeafType } from "../../utils/sim-utils";
+import { TrayType, TrayObject } from "../../utils/sim-utils";
 import { useDrag } from "react-dnd";
 import { usePreview } from "react-dnd-preview";
 

--- a/src/components/simulation/tray.tsx
+++ b/src/components/simulation/tray.tsx
@@ -36,7 +36,7 @@ export const Tray: React.FC<IProps> = (props) => {
       <SortingTray />
       <div className="header">
         <div className="title">{t("SORTINGTRAY")}</div>
-        <button className="close" onClick={onHideTray}>
+        <button className="close" onClick={onHideTray} aria-label={t("BUTTON.CLOSE")}>
           <CloseIcon />
         </button>
       </div>

--- a/src/components/thumbnail/thumbnail-chooser/thumbnail-wrapper.tsx
+++ b/src/components/thumbnail/thumbnail-chooser/thumbnail-wrapper.tsx
@@ -3,6 +3,7 @@ import { ThumbnailTitle } from "./thumbnail-title";
 import { ContainerId, IContainer } from "../../../hooks/use-model-state";
 import { IThumbnailProps } from "./thumbnail-chooser";
 import CloseIcon from "../../../assets/close-icon.svg";
+import t from "../../../utils/translation/translate";
 
 import "./thumbnail-wrapper.scss";
 
@@ -43,7 +44,7 @@ export const ThumbnailWrapper: React.FC<IThumbnailWrapperProps<Record<string, an
       { props.container && <div className={`container ${!props.selected ? " disabled" : ""}`}><props.Thumbnail container={props.container} /></div> }
       {
         props.selected &&
-        <button className="close" onClick={handleClose} disabled={props.disabled}>
+        <button className="close" onClick={handleClose} disabled={props.disabled} aria-label={t("BUTTON.CLOSE")}>
           <CloseIcon />
         </button>
       }

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     <title>Leaf Pack Simulation</title>

--- a/src/utils/sim-utils.ts
+++ b/src/utils/sim-utils.ts
@@ -129,7 +129,9 @@ export interface Environment {
   type: EnvironmentType;
   name: string;
   backgroundImage: any;
+  backgroundImageAltText: string;
   sketchImage: any;
+  sketchImageAltText: string;
 }
 
 export const Environments: Environment[] = [
@@ -137,25 +139,33 @@ export const Environments: Environment[] = [
     type: EnvironmentType.environment1,
     name: t("ENVIRONMENT.1"),
     backgroundImage: EnvironmentImage1,
-    sketchImage: EnvironmentSketchImage1
+    backgroundImageAltText: t("ENVIRONMENT1.DESCRIPTION"),
+    sketchImage: EnvironmentSketchImage1,
+    sketchImageAltText: t("ENVIRONMENT.SKETCH.DESCRIPTION")
   },
   {
     type: EnvironmentType.environment2,
     name: t("ENVIRONMENT.2"),
     backgroundImage: EnvironmentImage2,
-    sketchImage: EnvironmentSketchImage2
+    backgroundImageAltText: t("ENVIRONMENT2.DESCRIPTION"),
+    sketchImage: EnvironmentSketchImage2,
+    sketchImageAltText: t("ENVIRONMENT.SKETCH.DESCRIPTION")
   },
   {
     type: EnvironmentType.environment3,
     name: t("ENVIRONMENT.3"),
     backgroundImage: EnvironmentImage3,
-    sketchImage: EnvironmentSketchImage3
+    backgroundImageAltText: t("ENVIRONMENT3.DESCRIPTION"),
+    sketchImage: EnvironmentSketchImage3,
+    sketchImageAltText: t("ENVIRONMENT.SKETCH.DESCRIPTION")
   },
   {
     type: EnvironmentType.environment4,
     name: t("ENVIRONMENT.4"),
     backgroundImage: EnvironmentImage4,
-    sketchImage: EnvironmentSketchImage4
+    backgroundImageAltText: t("ENVIRONMENT4.DESCRIPTION"),
+    sketchImage: EnvironmentSketchImage4,
+    sketchImageAltText: t("ENVIRONMENT.SKETCH.DESCRIPTION")
   },
 ];
 
@@ -451,12 +461,13 @@ export const LeafPackConfigurations: LeafPackConfiguration[] = [
 export interface LeafPackState {
   leafDecomposition: LeafDecompositionType;
   image: any;
+  altText: string;
 }
 
 export const LeafPackStates: LeafPackState[] = [
-  { leafDecomposition: LeafDecompositionType.little, image: LeafPackImage1 },
-  { leafDecomposition: LeafDecompositionType.some, image: LeafPackImage2 },
-  { leafDecomposition: LeafDecompositionType.lots, image: LeafPackImage3 }
+  { leafDecomposition: LeafDecompositionType.little, image: LeafPackImage1, altText: t("LEAFPACK.LITTLE") },
+  { leafDecomposition: LeafDecompositionType.some, image: LeafPackImage2, altText: t("LEAFPACK.SOME") },
+  { leafDecomposition: LeafDecompositionType.lots, image: LeafPackImage3, altText: t("LEAFPACK.LOTS") }
 ];
 
 // The content that we position and display visually on the sim
@@ -478,6 +489,7 @@ export interface SimAnimal {
   type: SimAnimationType;
   frames: any[],
   layouts: SimAnimationLayout[],
+  altText: string;
 }
 
 export const SimAnimals: SimAnimal[] = [
@@ -507,7 +519,8 @@ export const SimAnimals: SimAnimal[] = [
       { environment: EnvironmentType.environment4, left: 100, top: 100, xScale: .5, yScale: .5, rotation: 0 },
       { environment: EnvironmentType.environment4, left: 100, top: 100, xScale: .5, yScale: .5, rotation: 0 },
       { environment: EnvironmentType.environment4, left: 100, top: 100, xScale: .5, yScale: .5, rotation: 0 },
-    ]
+    ],
+    altText: t("SIMANIMAL.FISH")
   },
 ];
 
@@ -518,6 +531,7 @@ export interface SimAnimation {
   xScale: number;
   yScale: number;
   rotation: number;
+  altText: string;
 }
 
 // The content that is positioned and shown in the tray

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -5,6 +5,7 @@
   "BUTTON.REWIND": "Rewind",
   "BUTTON.START": "Start",
   "BUTTON.PAUSE": "Pause",
+  "BUTTON.CLOSE": "Close",
 
   "LABEL.TIME_WEEK": "%{weeks} Week",
   "LABEL.TIME_WEEKS": "%{weeks} Weeks",
@@ -19,6 +20,17 @@
   "ENVIRONMENT.2": "Stream 2",
   "ENVIRONMENT.3": "Stream 3",
   "ENVIRONMENT.4": "Stream 4",
+
+  "ENVIRONMENT.SKETCH.DESCRIPTION": "A sketch of a stream",
+  "ENVIRONMENT1.DESCRIPTION": "A stream in a forest",
+  "ENVIRONMENT2.DESCRIPTION": "A stream in a forest with buildings in the distance",
+  "ENVIRONMENT3.DESCRIPTION": "A stream running from the edge of a city into a forest",
+  "ENVIRONMENT4.DESCRIPTION": "A stream running through a city",
+
+  "LEAFPACK.LITTLE": "A leafpack with little decomposition",
+  "LEAFPACK.SOME": "A leafpack with some decomposition",
+  "LEAFPACK.LOTS": "A leafpack with lots of decomposition",
+  "SIMANIMAL.FISH": "A fish",
 
   "NOTEBOOK.HABITAT": "Habitat",
   "NOTEBOOK.MACRO": "Macroinvertebrates",

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -5,6 +5,7 @@
   "BUTTON.REWIND": "Rebobinar",
   "BUTTON.START": "Comienzo",
   "BUTTON.PAUSE": "Pausa",
+  "BUTTON.CLOSE": "Cerrar",
 
   "LABEL.TIME_WEEK": "%{weeks} Semana",
   "LABEL.TIME_WEEKS": "%{weeks} Semanas",
@@ -19,6 +20,17 @@
   "ENVIRONMENT.2": "Corriente 2",
   "ENVIRONMENT.3": "Corriente 3",
   "ENVIRONMENT.4": "Corriente 4",
+
+  "ENVIRONMENT.SKETCH.DESCRIPTION": "Un boceto de un arroyo",
+  "ENVIRONMENT1.DESCRIPTION": "Un arroyo en un bosque",
+  "ENVIRONMENT2.DESCRIPTION": "Un arroyo en un bosque con edificios en la distancia",
+  "ENVIRONMENT3.DESCRIPTION": "Un arroyo que va desde el borde de una ciudad hacia un bosque",
+  "ENVIRONMENT4.DESCRIPTION": "Un arroyo que atraviesa una ciudad",
+
+  "LEAFPACK.LITTLE": "Un paquete de hojas con poca descomposición",
+  "LEAFPACK.SOME": "Un paquete de hojas con algo de descomposición",
+  "LEAFPACK.LOTS": "Un paquete de hojas con mucha descomposición",
+  "SIMANIMAL.FISH": "Un pez",
 
   "NOTEBOOK.HABITAT": "Habitat",
   "NOTEBOOK.MACRO": "Macroinvertebrados",


### PR DESCRIPTION
I ran the current working version of the leafpack project through the Chrome Lighthouse tools and was disappointed to get an accessibility score of 80.  With some quick fixes, I was able to bring this score up to a 98.  Improvements include:
- add image `alt` attributes
- add `aria` attributes
- set default language