### PR TITLE
State saving improvements [#176507583]

### DIFF
--- a/src/assets/chemistry-icon.svg
+++ b/src/assets/chemistry-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g fill="none" fill-rule="evenodd">
         <g>
             <g>

--- a/src/assets/habitat-icon.svg
+++ b/src/assets/habitat-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g fill="none" fill-rule="evenodd">
         <g>
             <g>

--- a/src/assets/macro-icon.svg
+++ b/src/assets/macro-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g fill="none" fill-rule="evenodd">
         <g>
             <g>

--- a/src/assets/pti-icon.svg
+++ b/src/assets/pti-icon.svg
@@ -2,7 +2,7 @@
     <g fill="none" fill-rule="evenodd">
         <g>
             <g>
-                <path d="M0 0H24V24H0z" transform="translate(-280 -1653) translate(280 1653)"/>
+                <!-- <path d="M0 0H24V24H0z" transform="translate(-280 -1653) translate(280 1653)"/> -->
                 <path fill="#333" fill-rule="nonzero" d="M12 1c3.333 2.2 6.267 3.3 8.8 3.3v6.699c0 5.555-3.751 10.736-8.8 12.001-5.049-1.265-8.8-6.446-8.8-12.001V4.3C5.733 4.3 8.667 3.2 12 1zm2.025 5.3h-4.05v3.375H6.6v4.05h3.375V17.1h4.05v-3.375H17.4v-4.05h-3.375V6.3z" transform="translate(-280 -1653) translate(280 1653)"/>
             </g>
         </g>

--- a/src/components/notebook/habitat-panel.tsx
+++ b/src/components/notebook/habitat-panel.tsx
@@ -10,7 +10,7 @@ const kCategoriesPerSection = 3;
 
 interface IProps {
   environment: EnvironmentType;
-  featureSelections: Record<HabitatFeatureType, boolean>;
+  featureSelections: Set<HabitatFeatureType>;
   onSelectFeature: (feture: HabitatFeatureType, selected: boolean) => void;
   isRunning: boolean;
 }
@@ -41,8 +41,8 @@ export const HabitatPanel: React.FC<IProps> = (props) => {
               ? category.features.map((feature, fIndex) =>
                   <div className="feature-row" key={`feature-row-${fIndex}`}>
                     <button
-                      className={`checkbox ${featureSelections[feature] ? "selected" : ""}`}
-                      onClick={() => onSelectFeature(feature, !featureSelections[feature])}
+                      className={`checkbox ${featureSelections.has(feature) ? "selected" : ""}`}
+                      onClick={() => onSelectFeature(feature, !featureSelections.has(feature))}
                       aria-label={habitatFeatures.find((f) => f.type === feature)?.label}
                     >
                       <CheckIcon />

--- a/src/components/notebook/notebook.scss
+++ b/src/components/notebook/notebook.scss
@@ -26,6 +26,7 @@
     border: solid 1px $gray-dark;
     background-color: $gray-dark10;
     padding: 4px 4px 0 4px;
+    font-weight: bold;
     cursor: pointer;
 
     .inner {
@@ -38,6 +39,8 @@
     }
 
     .icon {
+      width: 24px;
+      height: 24px;
       margin-right: 5px;
     }
 

--- a/src/components/notebook/notebook.tsx
+++ b/src/components/notebook/notebook.tsx
@@ -16,8 +16,8 @@ import "./notebook.scss";
 interface IProps {
   trayObjects: TrayObject[];
   environment: EnvironmentType;
-  featureSelections: Record<HabitatFeatureType, boolean>;
-  onSelectFeature: (feture: HabitatFeatureType, selected: boolean) => void;
+  featureSelections: Set<HabitatFeatureType>;
+  onSelectFeature: (feature: HabitatFeatureType, selected: boolean) => void;
   onCategorizeAnimal: (trayType: TrayType | undefined, notebookType: TrayType | undefined) => void;
   traySelectionType?: TrayType;
   isRunning: boolean;

--- a/src/components/simulation/main-view-wrapper.tsx
+++ b/src/components/simulation/main-view-wrapper.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import t from "../../utils/translation/translate";
-import { ProgressBar, SaveButton } from "@concord-consortium/react-components";
-import "./main-view-wrapper.scss";
+import { ProgressBar } from "@concord-consortium/react-components";
 import { ThumbnailTitle } from "../thumbnail/thumbnail-chooser/thumbnail-title";
+
+import "./main-view-wrapper.scss";
 
 export interface IMainViewWrapperProps {
   title: string;
@@ -16,7 +16,7 @@ export interface IMainViewWrapperProps {
 }
 
 export const MainViewWrapper: React.FC<IMainViewWrapperProps> = (props) => {
-  const { title, isSaved, isFinished, onSaveClicked, children, currentTime, maxTime, currentTimeLabel, savedBgColor } = props;
+  const { title, isSaved, children, currentTime, maxTime, currentTimeLabel, savedBgColor } = props;
   return (
     <div className="main-view-wrapper">
       <ThumbnailTitle title={title} empty={false} saved={isSaved} savedBgColor={savedBgColor} />
@@ -30,14 +30,14 @@ export const MainViewWrapper: React.FC<IMainViewWrapperProps> = (props) => {
           currentTimeLabel={currentTimeLabel}
         />
       </div>
-      <div className="save-container">
+      {/* <div className="save-container">
         <SaveButton
           label={isSaved ? t("BUTTON.SAVED") : t("BUTTON.SAVE")}
           customClassName={isSaved ? "saved-btn" : ""}
           onClick={onSaveClicked}
           disabled={!isFinished || isSaved}
         />
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/src/components/thumbnail/thumbnail-chooser/thumbnail-chooser.test.tsx
+++ b/src/components/thumbnail/thumbnail-chooser/thumbnail-chooser.test.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { IThumbnailChooserProps, ThumbnailChooser } from "./thumbnail-chooser";
-import { ContainerId, IContainer, initialSimulationState } from "../../../hooks/use-model-state";
+import {
+  ContainerId, ContainerIds, IContainer, initContainerMap, initialSimulationState
+} from "../../../hooks/use-model-state";
 
 interface IModelInputState {
   foo: boolean;
@@ -24,7 +26,7 @@ describe("ThumbnailChooser component", () => {
     const Thumbnail = () => <div data-testid="thumbnail">Thumbnail</div>;
 
     const thumbnailChooserProps: IThumbnailChooserProps<IModelInputState, IModelOutputState> = {
-      containers: {"A": container, "B": null, "C": null, "D": null, "E": null},
+      containers: initContainerMap({"A": container}),
       Thumbnail,
       selectedContainerId: "A",
       setSelectedContainerId: (containerId: ContainerId) => undefined,
@@ -35,7 +37,7 @@ describe("ThumbnailChooser component", () => {
 
     render(<ThumbnailChooser {...thumbnailChooserProps} />);
     expect(screen.getAllByTestId("thumbnail-chooser")).toHaveLength(1);
-    expect(screen.getAllByTestId("thumbnail-wrapper")).toHaveLength(5);
+    expect(screen.getAllByTestId("thumbnail-wrapper")).toHaveLength(ContainerIds.length);
     expect(screen.getAllByTestId("thumbnail")).toHaveLength(1);
   });
 });

--- a/src/components/thumbnail/thumbnail-chooser/thumbnail-chooser.tsx
+++ b/src/components/thumbnail/thumbnail-chooser/thumbnail-chooser.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ContainerId, IContainer } from "../../../hooks/use-model-state";
+import { ContainerId, ContainerIds, IContainer } from "../../../hooks/use-model-state";
 import { ThumbnailWrapper } from "./thumbnail-wrapper";
 import t from "../../../utils/translation/translate";
 
@@ -28,7 +28,7 @@ export const ThumbnailChooser: React.FC<IThumbnailChooserProps<Record<string, an
     <div className="thumbnail-chooser" data-testid="thumbnail-chooser">
       <div className="thumbnail-chooser-title">{t("THUMBNAIL-CHOOSER.TITLE")}</div>
       <div className="thumbnail-chooser-list">
-        {Object.keys(containers).map((containerId: ContainerId) => {
+        {ContainerIds.map(containerId => {
           const container = containers[containerId];
           const selected = containerId === selectedContainerId;
           return (

--- a/src/components/thumbnail/thumbnail-chooser/thumbnail-chooser.tsx
+++ b/src/components/thumbnail/thumbnail-chooser/thumbnail-chooser.tsx
@@ -11,7 +11,8 @@ export interface IThumbnailProps<IModelInputState, IModelOutputState> {
 
 export interface IThumbnailChooserProps<IModelInputState, IModelOutputState> {
   containers: Record<ContainerId, IContainer<IModelInputState, IModelOutputState> | null>;
-  Thumbnail: React.FC<IThumbnailProps<IModelInputState, IModelOutputState>>
+  Thumbnail: React.FC<IThumbnailProps<IModelInputState, IModelOutputState>>;
+  disableUnselectedThumbnails?: boolean;
   selectedContainerId: ContainerId;
   setSelectedContainerId: (containerId: ContainerId) => void;
   clearContainer: (containerId: ContainerId) => void;
@@ -20,10 +21,10 @@ export interface IThumbnailChooserProps<IModelInputState, IModelOutputState> {
 }
 
 export const ThumbnailChooser: React.FC<IThumbnailChooserProps<Record<string, any>, Record<string, any>>> = (props) => {
-  const { containers, Thumbnail, selectedContainerId, setSelectedContainerId, clearContainer, savedBgColor,
-    selectedContainerBgColor } = props;
+  const { containers, Thumbnail, disableUnselectedThumbnails, selectedContainerId, setSelectedContainerId, clearContainer,
+          savedBgColor, selectedContainerBgColor } = props;
   // Disable unselected thumbnails until user saves the current one.
-  const unselectedThumbnailsDisabled = !containers[selectedContainerId]?.inputState;
+  const unselectedThumbnailsDisabled = disableUnselectedThumbnails ?? !containers[selectedContainerId]?.inputState;
   return (
     <div className="thumbnail-chooser" data-testid="thumbnail-chooser">
       <div className="thumbnail-chooser-title">{t("THUMBNAIL-CHOOSER.TITLE")}</div>

--- a/src/components/thumbnail/thumbnail-chooser/thumbnail-wrapper.tsx
+++ b/src/components/thumbnail/thumbnail-chooser/thumbnail-wrapper.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { ThumbnailTitle } from "./thumbnail-title";
 import { ContainerId, IContainer } from "../../../hooks/use-model-state";
 import { IThumbnailProps } from "./thumbnail-chooser";
-import CloseIcon from "../../../assets/close-icon.svg";
-import t from "../../../utils/translation/translate";
+// import CloseIcon from "../../../assets/close-icon.svg";
+// import t from "../../../utils/translation/translate";
 
 import "./thumbnail-wrapper.scss";
 
@@ -24,30 +24,30 @@ export const ThumbnailWrapper: React.FC<IThumbnailWrapperProps<Record<string, an
   const style = {backgroundColor: props.selected ? props.selectedContainerBgColor : undefined};
   const isSaved = !!props.container?.isSaved;
   const handleSelect = (e: React.MouseEvent<HTMLButtonElement>) => props.setSelectedContainerId(props.containerId);
-  const handleClose = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    props.clearContainer(props.containerId);
-  };
+  // const handleClose = (e: React.MouseEvent<HTMLButtonElement>) => {
+  //   e.stopPropagation();
+  //   props.clearContainer(props.containerId);
+  // };
 
   return (
     <div className="thumbnail-wrapper" data-testid="thumbnail-wrapper">
       <button className={className} style={style} data-testid="thumbnail-button" onClick={handleSelect} disabled={props.disabled}>
         <ThumbnailTitle title={props.containerId} empty={!props.selected} saved={isSaved} savedBgColor={props.savedBgColor} />
-        {
+        {/* {
           !props.selected &&
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
             <line x1="8" y1="0" x2="8" y2="16" strokeWidth="2.5"/>
             <line x1="0" y1="8" x2="16" y2="8" strokeWidth="2.5"/>
           </svg>
-        }
+        } */}
       </button>
       { props.container && <div className={`container ${!props.selected ? " disabled" : ""}`}><props.Thumbnail container={props.container} /></div> }
-      {
+      {/* {
         props.selected &&
         <button className="close" onClick={handleClose} disabled={props.disabled} aria-label={t("BUTTON.CLOSE")}>
           <CloseIcon />
         </button>
-      }
+      } */}
     </div>
   );
 };

--- a/src/components/thumbnail/thumbnail-chooser/thumbnail-wrapper.tsx
+++ b/src/components/thumbnail/thumbnail-chooser/thumbnail-wrapper.tsx
@@ -20,10 +20,12 @@ export interface IThumbnailWrapperProps<IModelInputState, IModelOutputState> {
 }
 
 export const ThumbnailWrapper: React.FC<IThumbnailWrapperProps<Record<string, any>, Record<string, any>>> = (props) => {
-  const className = `thumbnail-button${props.selected ? " selected" : ""}${!props.container ? " empty" : ""}`;
-  const style = {backgroundColor: props.selected ? props.selectedContainerBgColor : undefined};
-  const isSaved = !!props.container?.isSaved;
-  const handleSelect = (e: React.MouseEvent<HTMLButtonElement>) => props.setSelectedContainerId(props.containerId);
+  const { containerId, selected, setSelectedContainerId, disabled, Thumbnail, container,
+          savedBgColor, selectedContainerBgColor } = props;
+  const className = `thumbnail-button${selected ? " selected" : ""}${!container ? " empty" : ""}`;
+  const style = {backgroundColor: selected ? selectedContainerBgColor : undefined};
+  const isSaved = !!container?.isSaved;
+  const handleSelect = (e: React.MouseEvent<HTMLElement>) => setSelectedContainerId(containerId);
   // const handleClose = (e: React.MouseEvent<HTMLButtonElement>) => {
   //   e.stopPropagation();
   //   props.clearContainer(props.containerId);
@@ -31,8 +33,8 @@ export const ThumbnailWrapper: React.FC<IThumbnailWrapperProps<Record<string, an
 
   return (
     <div className="thumbnail-wrapper" data-testid="thumbnail-wrapper">
-      <button className={className} style={style} data-testid="thumbnail-button" onClick={handleSelect} disabled={props.disabled}>
-        <ThumbnailTitle title={props.containerId} empty={!props.selected} saved={isSaved} savedBgColor={props.savedBgColor} />
+      <button className={className} style={style} data-testid="thumbnail-button" onClick={handleSelect} disabled={disabled}>
+        <ThumbnailTitle title={containerId} empty={!selected} saved={isSaved} savedBgColor={savedBgColor} />
         {/* {
           !props.selected &&
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
@@ -41,7 +43,10 @@ export const ThumbnailWrapper: React.FC<IThumbnailWrapperProps<Record<string, an
           </svg>
         } */}
       </button>
-      { props.container && <div className={`container ${!props.selected ? " disabled" : ""}`}><props.Thumbnail container={props.container} /></div> }
+      { container &&
+        <div className={`container ${!selected ? " disabled" : ""}`} onClick={disabled ? undefined : handleSelect}>
+          <Thumbnail container={container} />
+        </div> }
       {/* {
         props.selected &&
         <button className="close" onClick={handleClose} disabled={props.disabled} aria-label={t("BUTTON.CLOSE")}>

--- a/src/components/thumbnail/thumbnail.scss
+++ b/src/components/thumbnail/thumbnail.scss
@@ -5,36 +5,68 @@
   width: 90px;
   position: relative;
   font-family: Verdana, Geneva, Tahoma, sans-serif;
+  font-size: 14px;
 
-  .foreground {
+  .environment {
     position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-  }
-
-  .inputs {
+    left: 40px;
+    top: 2px;
     display: flex;
     flex-direction: row;
     justify-content: center;
-    align-items: flex-end;
-    height: 90%;
+    align-items: center;
+    margin: 5px;
 
-    .environment {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      margin: 5px;
+    svg {
+      margin-right: 2px;
     }
+  }
 
-    .sunny-days {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      margin: 5px;
+  .sunny-days {
+    position: absolute;
+    left: 0;
+    top: 30px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    margin: 5px;
+
+    svg {
+      margin-right: 2px;
+    }
+  }
+
+  .pollution-tolerance {
+    position: absolute;
+    left: 42px;
+    top: 30px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    margin: 5px;
+
+    svg {
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .notebook-row {
+    position: absolute;
+    top: 64px;
+    left: 0;
+    width: calc(100% - 10px);
+    padding: 0 5px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    align-items: center;
+
+    svg {
+      width: 20px;
+      height: 20px;
     }
   }
 

--- a/src/components/thumbnail/thumbnail.test.tsx
+++ b/src/components/thumbnail/thumbnail.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { Thumbnail } from "./thumbnail";
+import { IContainer } from "../../hooks/use-model-state";
+import { IModelInputState, IModelOutputState } from "../app";
+import { AlgaeEatersAmountType, EnvironmentType, FishAmountType, LeafDecompositionType, LeafEatersAmountType } from "../../utils/sim-utils";
+
+describe("Thumbnail component", () => {
+  const emptyContainer: IContainer<IModelInputState, IModelOutputState> = {
+    inputState: { environment: EnvironmentType.environment1, sunnyDayFequency: 0 },
+    outputState: {
+      leafDecomposition: LeafDecompositionType.little,
+      leafEaters: LeafEatersAmountType.few,
+      algaeEaters: AlgaeEatersAmountType.few,
+      fish: FishAmountType.few,
+      animalInstances: [],
+      showTray: false,
+      trayObjects: [],
+      habitatFeatures: new Set() },
+    simulationState: { isRunning: false, isPaused: false, isFinished: true },
+    isSaved: true
+  };
+
+  it("renders empty thumbnail", () => {
+    render(<Thumbnail container={emptyContainer} />);
+    expect(screen.getByTestId("environment-label")).toHaveTextContent("1");
+    expect(screen.getByTestId("sunny-days-label")).toHaveTextContent("F");
+    expect(screen.getByTestId("pollution-tolerance-label")).toHaveTextContent("");
+    expect(screen.getByTestId("habitat-icon")).not.toBeVisible();
+    expect(screen.getByTestId("macroinvertebrates-icon")).not.toBeVisible();
+    expect(screen.getByTestId("chemistry-icon")).not.toBeVisible();
+  });
+});

--- a/src/components/thumbnail/thumbnail.tsx
+++ b/src/components/thumbnail/thumbnail.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { IThumbnailProps } from "./thumbnail-chooser/thumbnail-chooser";
 import { IModelInputState, IModelOutputState } from "../app";
 import IconEnvironment from "../../assets/stream-icon.svg";
+import IconChemistryNotebook from "../../assets/chemistry-icon.svg";
+import IconHabitatNotebook from "../../assets/habitat-icon.svg";
+import IconMacroinvertebratesNotebook from "../../assets/macro-icon.svg";
+import IconPTI from "../../assets/pti-icon.svg";
 import IconSun from "../../assets/sunny-icon.svg";
 import { Environments } from "../../utils/sim-utils";
 import t from "../../utils/translation/translate";
@@ -9,21 +13,28 @@ import t from "../../utils/translation/translate";
 import "./thumbnail.scss";
 
 export const Thumbnail: React.FC<IThumbnailProps<IModelInputState, IModelOutputState>> = (props) => {
-  const {inputState} = props.container;
-  const {sunnyDayFequency, environment} = inputState;
+  const {inputState: {environment, sunnyDayFequency}, outputState: {pti}} = props.container;
+  const {showHabitat, showMacro, showChemistry} = { showHabitat: true, showMacro: true, showChemistry: true }; // outputState
   const sunnyDays = sunnyDayFequency === 0 ? t("SUNNYDAY.FEW.SHORT") : t("SUNNYDAY.MANY.SHORT");
   const environmentIndex = Environments.findIndex((e) => e.type === environment) + 1;
   return (
     <div className="thumbnail" data-testid="thumbnail">
-      <div className="inputs">
-        <div className="environment">
-          <IconEnvironment />
-          <div className="label">{environmentIndex}</div>
-        </div>
-        <div className="sunny-days">
-          <IconSun />
-          <div className="label">{t(sunnyDays)}</div>
-        </div>
+      <div className="environment">
+        <IconEnvironment />
+        <div className="label">{environmentIndex}</div>
+      </div>
+      <div className="sunny-days">
+        <IconSun />
+        <div className="label">{t(sunnyDays)}</div>
+      </div>
+      <div className="pollution-tolerance">
+        <IconPTI />
+        <div className="label">{pti}</div>
+      </div>
+      <div className="notebook-row">
+        {showHabitat && <IconHabitatNotebook />}
+        {showMacro && <IconMacroinvertebratesNotebook />}
+        {showChemistry && <IconChemistryNotebook />}
       </div>
     </div>
   );

--- a/src/components/thumbnail/thumbnail.tsx
+++ b/src/components/thumbnail/thumbnail.tsx
@@ -24,20 +24,26 @@ export const Thumbnail: React.FC<IThumbnailProps<IModelInputState, IModelOutputS
     <div className="thumbnail" data-testid="thumbnail">
       <div className="environment">
         <IconEnvironment />
-        <div className="label">{environmentIndex}</div>
+        <div className="label" data-testid="environment-label">{environmentIndex}</div>
       </div>
       <div className="sunny-days">
         <IconSun />
-        <div className="label">{t(sunnyDays)}</div>
+        <div className="label" data-testid="sunny-days-label">{t(sunnyDays)}</div>
       </div>
       <div className="pollution-tolerance">
         <IconPTI />
-        <div className="label">{pti}</div>
+        <div className="label" data-testid="pollution-tolerance-label">{pti}</div>
       </div>
       <div className="notebook-row">
-        <IconHabitatNotebook style={{ visibility: showHabitatIcon ? "visible" : "hidden"}} />
-        <IconMacroinvertebratesNotebook style={{ visibility: showMacroinvertebratesIcon ? "visible" : "hidden"}} />
-        <IconChemistryNotebook style={{ visibility: showChemistryIcon ? "visible" : "hidden"}} />
+        <IconHabitatNotebook
+          style={{ visibility: showHabitatIcon ? "visible" : "hidden"}}
+          data-testid="habitat-icon" />
+        <IconMacroinvertebratesNotebook
+          style={{ visibility: showMacroinvertebratesIcon ? "visible" : "hidden"}}
+          data-testid="macroinvertebrates-icon" />
+        <IconChemistryNotebook
+          style={{ visibility: showChemistryIcon ? "visible" : "hidden"}}
+          data-testid="chemistry-icon" />
       </div>
     </div>
   );

--- a/src/components/thumbnail/thumbnail.tsx
+++ b/src/components/thumbnail/thumbnail.tsx
@@ -13,8 +13,11 @@ import t from "../../utils/translation/translate";
 import "./thumbnail.scss";
 
 export const Thumbnail: React.FC<IThumbnailProps<IModelInputState, IModelOutputState>> = (props) => {
-  const {inputState: {environment, sunnyDayFequency}, outputState: {pti}} = props.container;
-  const {showHabitat, showMacro, showChemistry} = { showHabitat: true, showMacro: true, showChemistry: true }; // outputState
+  const {inputState: {environment, sunnyDayFequency},
+        outputState: {habitatFeatures, pti}} = props.container;
+  const showHabitatIcon = habitatFeatures.size > 0;
+  const showMacroinvertebratesIcon = (pti ?? 0) > 0;
+  const showChemistryIcon = false;  // TODO: figure out criteria for showing chemistry icon
   const sunnyDays = sunnyDayFequency === 0 ? t("SUNNYDAY.FEW.SHORT") : t("SUNNYDAY.MANY.SHORT");
   const environmentIndex = Environments.findIndex((e) => e.type === environment) + 1;
   return (
@@ -32,9 +35,9 @@ export const Thumbnail: React.FC<IThumbnailProps<IModelInputState, IModelOutputS
         <div className="label">{pti}</div>
       </div>
       <div className="notebook-row">
-        {showHabitat && <IconHabitatNotebook />}
-        {showMacro && <IconMacroinvertebratesNotebook />}
-        {showChemistry && <IconChemistryNotebook />}
+        <IconHabitatNotebook style={{ visibility: showHabitatIcon ? "visible" : "hidden"}} />
+        <IconMacroinvertebratesNotebook style={{ visibility: showMacroinvertebratesIcon ? "visible" : "hidden"}} />
+        <IconChemistryNotebook style={{ visibility: showChemistryIcon ? "visible" : "hidden"}} />
       </div>
     </div>
   );

--- a/src/hooks/use-model-state.test.ts
+++ b/src/hooks/use-model-state.test.ts
@@ -25,6 +25,10 @@ const initialOutputState: IModelOutputState = {
 };
 
 const initialTransientState: IModelTransientState = {
+  baz: 0
+};
+
+const finalTransientState: IModelTransientState = {
   baz: 1000
 };
 
@@ -47,6 +51,7 @@ describe("useModelState", () => {
       initialInputState,
       initialOutputState,
       initialTransientState,
+      finalTransientState,
       onStateChange,
       addExternalSetStateListener,
       removeExternalSetStateListener,
@@ -272,6 +277,7 @@ describe("useModelState", () => {
       initialInputState,
       initialOutputState,
       initialTransientState,
+      finalTransientState,
       onStateChange,
       addExternalSetStateListener: testAddExternalSetStateListener,
       removeExternalSetStateListener,

--- a/src/hooks/use-model-state.ts
+++ b/src/hooks/use-model-state.ts
@@ -49,6 +49,7 @@ export interface IUseModelStateOptions<IModelInputState, IModelOutputState, IMod
   initialInputState: IModelInputState;
   initialOutputState: IModelOutputState;
   initialTransientState: IModelTransientState;
+  finalTransientState: IModelTransientState;
   onStateChange: ModelStateChangeCallback<IModelInputState, IModelOutputState>;
   addExternalSetStateListener: (listener: ExternalSetStateListenerCallback<IModelInputState, IModelOutputState>) => void;
   removeExternalSetStateListener: (listener: ExternalSetStateListenerCallback<IModelInputState, IModelOutputState>) => void;
@@ -61,7 +62,8 @@ export const hasOwnProperties = (obj: Record<string, any>, properties: string[])
 export const useModelState = <IModelInputState, IModelOutputState, IModelTransientState>(options: IUseModelStateOptions<IModelInputState, IModelOutputState, IModelTransientState>) => {
   type ContainerMap = IContainerMap<IModelInputState, IModelOutputState>;
 
-  const {initialInputState, initialOutputState, initialTransientState, onStateChange, addExternalSetStateListener, removeExternalSetStateListener, isValidExternalState, logEvent} = options;
+  const {initialInputState, initialOutputState, initialTransientState, finalTransientState,
+        onStateChange, addExternalSetStateListener, removeExternalSetStateListener, isValidExternalState, logEvent} = options;
   const [inputState, _setInputState] = useState<IModelInputState>(initialInputState);
   const [outputState, _setOutputState] = useStateWithCallbackLazy<IModelOutputState>(initialOutputState);
   const [transientState, _setTransientState] = useState<IModelTransientState>(initialTransientState);
@@ -126,9 +128,9 @@ export const useModelState = <IModelInputState, IModelOutputState, IModelTransie
         _setSelectedContainerId(containerId);
         _setInputState(container?.inputState || initialInputState);
 
-        _setOutputState(initialOutputState);
+        _setOutputState(container?.outputState || initialOutputState);
         _setSimulationState(initialSimulationState);
-        _setTransientState(initialTransientState);
+        _setTransientState(container?.outputState ? finalTransientState : initialTransientState);
 
         _setIsDirty(false);
         _setIsSaved(!!container?.isSaved);

--- a/src/hooks/use-model-state.ts
+++ b/src/hooks/use-model-state.ts
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { ExternalSetStateListenerCallback, LogEventMethod } from "../components/render-app";
+import { useStateWithCallbackLazy } from "./use-state-with-callback";
 
-export type ContainerId = "A" | "B" | "C" | "D" | "E"
+// cf. https://stackoverflow.com/a/45486495
+export const ContainerIds = ["A", "B", "C", "D"] as const;
+export type ContainerId = typeof ContainerIds[number];
 
 export interface ISimulationState {
   isRunning: boolean;
@@ -22,10 +25,21 @@ export interface IContainer<IModelInputState, IModelOutputState> {
   isSaved: boolean;
 }
 
+export type IContainerMap<IModelInputState, IModelOutputState> = Record<ContainerId, IContainer<IModelInputState, IModelOutputState> | null>;
+export type IPartialContainerMap<IModelInputState, IModelOutputState> = Partial<IContainerMap<IModelInputState, IModelOutputState>>;
+
+export const initContainerMap = <IModelInputState, IModelOutputState>(
+  input?: IPartialContainerMap<IModelInputState, IModelOutputState>
+): IContainerMap<IModelInputState, IModelOutputState> => {
+  const result: IPartialContainerMap<IModelInputState, IModelOutputState> = {};
+  for (const id of ContainerIds) result[id] = null;
+  return { ...result, ...input } as IContainerMap<IModelInputState, IModelOutputState>;
+};
+
 export interface IModelCurrentState<IModelInputState, IModelOutputState> {
   inputState: IModelInputState;
   outputState: IModelOutputState;
-  containers: Record<ContainerId, IContainer<IModelInputState, IModelOutputState> | null>;
+  containers: IContainerMap<IModelInputState, IModelOutputState>;
   selectedContainerId: ContainerId;
 }
 
@@ -45,21 +59,15 @@ export interface IUseModelStateOptions<IModelInputState, IModelOutputState, IMod
 export const hasOwnProperties = (obj: Record<string, any>, properties: string[]) => properties.reduce<boolean>((acc, prop) => acc && Object.prototype.hasOwnProperty.call(obj, prop), true);
 
 export const useModelState = <IModelInputState, IModelOutputState, IModelTransientState>(options: IUseModelStateOptions<IModelInputState, IModelOutputState, IModelTransientState>) => {
-  type ContainerMap = Record<ContainerId, IContainer<IModelInputState, IModelOutputState> | null>;
+  type ContainerMap = IContainerMap<IModelInputState, IModelOutputState>;
 
   const {initialInputState, initialOutputState, initialTransientState, onStateChange, addExternalSetStateListener, removeExternalSetStateListener, isValidExternalState, logEvent} = options;
   const [inputState, _setInputState] = useState<IModelInputState>(initialInputState);
-  const [outputState, _setOutputState] = useState<IModelOutputState>(initialOutputState);
+  const [outputState, _setOutputState] = useStateWithCallbackLazy<IModelOutputState>(initialOutputState);
   const [transientState, _setTransientState] = useState<IModelTransientState>(initialTransientState);
   const [simulationState, _setSimulationState] = useState<ISimulationState>(initialSimulationState);
   const [selectedContainerId, _setSelectedContainerId] = useState<ContainerId>("A");
-  const [containers, _setContainers] = useState<ContainerMap>({
-    "A": null,
-    "B": null,
-    "C": null,
-    "D": null,
-    "E": null,
-  });
+  const [containers, _setContainers] = useState<ContainerMap>(initContainerMap());
   const [isDirty, _setIsDirty] = useState(false);
   const [isSaved, _setIsSaved] = useState(false);
 
@@ -84,7 +92,7 @@ export const useModelState = <IModelInputState, IModelOutputState, IModelTransie
     };
     addExternalSetStateListener(listener);
     return () => removeExternalSetStateListener(listener);
-  }, [addExternalSetStateListener, removeExternalSetStateListener, isValidExternalState, initialTransientState]);
+  }, [addExternalSetStateListener, removeExternalSetStateListener, isValidExternalState, initialTransientState, _setOutputState]);
 
   // notify PCI about any state changes
   useEffect(() => {
@@ -100,7 +108,8 @@ export const useModelState = <IModelInputState, IModelOutputState, IModelTransie
   };
 
   const setOutputState = (update: Partial<IModelOutputState>) => {
-    _setOutputState(oldOutputState => ({...oldOutputState, ...update}));
+    _setOutputState(oldOutputState => ({...oldOutputState, ...update}),
+                    newOutputState => saveToSelectedContainer(newOutputState));
   };
 
   const setTransientState = (update: Partial<IModelTransientState>) => {
@@ -134,18 +143,19 @@ export const useModelState = <IModelInputState, IModelOutputState, IModelTransie
     logEvent("clear", {data: {containerId}, includeState: true});
     _setContainers(oldContainers => ({...oldContainers, [containerId]: null}));
 
-    const sortedKeys: ContainerId[] = Object.keys(containers).sort() as ContainerId[];
-    let lastNonEmptyBefore: string | null = null;
-    let firstNonEmptyAfter: string | null = null;
-    sortedKeys.forEach(key => {
-      if (key < containerId && containers[key]) {
-        lastNonEmptyBefore = key;
-      }
-      if (!firstNonEmptyAfter && key > containerId && containers[key]) {
-        firstNonEmptyAfter = key;
+    let lastNonEmptyBefore: ContainerId | null = null;
+    let firstNonEmptyAfter: ContainerId | null = null;
+    ContainerIds.forEach(key => {
+      if (containers[key]) {
+        if ((key as string) < (containerId as string)) {
+          lastNonEmptyBefore = key;
+        }
+        if (!firstNonEmptyAfter && (key as string) > (containerId as string)) {
+          firstNonEmptyAfter = key;
+        }
       }
     });
-    const containerToSelect = lastNonEmptyBefore || firstNonEmptyAfter;
+    const containerToSelect: ContainerId | null = lastNonEmptyBefore || firstNonEmptyAfter;
     if (containerToSelect) {
       setSelectedContainerId(containerToSelect);
     } else {
@@ -160,11 +170,13 @@ export const useModelState = <IModelInputState, IModelOutputState, IModelTransie
     }
   };
 
-  const saveToSelectedContainer = () => {
+  const saveToSelectedContainer = (output?: IModelOutputState) => {
     _setContainers(oldContainers => {
-      logEvent("save", {data: {containerId: selectedContainerId, inputState, outputState}, includeState: true});
+      // `output` argument can be more current than closure's `outputState`
+      const _outputState = output ?? outputState;
+      logEvent("save", {data: {containerId: selectedContainerId, inputState, outputState: _outputState}, includeState: true});
       const newContainer: IContainer<IModelInputState, IModelOutputState> = {
-        inputState, outputState, simulationState, isSaved: true
+        inputState, outputState: _outputState, simulationState, isSaved: true
       };
       return {...oldContainers, [selectedContainerId]: newContainer};
     });

--- a/src/hooks/use-state-with-callback.ts
+++ b/src/hooks/use-state-with-callback.ts
@@ -1,0 +1,44 @@
+// cf. https://github.com/the-road-to-learn-react/use-state-with-callback
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
+
+const useStateWithCallback = <T>(initialState: T, callback: (state?: T) => void) => {
+  const [state, setState] = useState(initialState);
+
+  useEffect(() => callback(state), [state, callback]);
+
+  return [state, setState] as const;
+};
+
+const useStateWithCallbackInstant = <T>(initialState: T, callback: (state?: T) => void) => {
+  const [state, setState] = useState(initialState);
+
+  useLayoutEffect(() => callback(state), [state, callback]);
+
+  return [state, setState] as const;
+};
+
+const useStateWithCallbackLazy = <T>(initialState: T) => {
+  const callbackRef = useRef<((state?: T) => void) | null>(null);
+
+  const [value, setValue] = useState(initialState);
+
+  useEffect(() => {
+    callbackRef.current?.(value);
+    callbackRef.current = null;
+  }, [value]);
+
+  const setValueWithCallback = useCallback((newValueOrFn: React.SetStateAction<T>, callback?: (state?: T) => void) => {
+    callbackRef.current = callback ?? null;
+
+    const newValue = typeof newValueOrFn === "function"
+                      ? (newValueOrFn as ((prevState: T) => T))(value)
+                      : newValueOrFn;
+    return setValue(newValue);
+  }, [value]);
+
+  return [value, setValueWithCallback] as const;
+};
+
+export { useStateWithCallbackInstant, useStateWithCallbackLazy };
+
+export default useStateWithCallback;

--- a/src/hooks/use-state-with-callback.ts
+++ b/src/hooks/use-state-with-callback.ts
@@ -29,12 +29,8 @@ const useStateWithCallbackLazy = <T>(initialState: T) => {
 
   const setValueWithCallback = useCallback((newValueOrFn: React.SetStateAction<T>, callback?: (state?: T) => void) => {
     callbackRef.current = callback ?? null;
-
-    const newValue = typeof newValueOrFn === "function"
-                      ? (newValueOrFn as ((prevState: T) => T))(value)
-                      : newValueOrFn;
-    return setValue(newValue);
-  }, [value]);
+    setValue(newValueOrFn);
+  }, []);
 
   return [value, setValueWithCallback] as const;
 };

--- a/src/utils/sim-utils.ts
+++ b/src/utils/sim-utils.ts
@@ -97,6 +97,7 @@ import { stoneFlySelectionPath, mayFlySelectionPath, caddisFlySelectionPath, dob
 } from "./selection-utils";
 
 import t from "./translation/translate";
+import { ContainerId } from "../hooks/use-model-state";
 
 export const sunnyDaySliderMarks = [
   {
@@ -124,6 +125,20 @@ export enum EnvironmentType {
   environment3 = "environment3",
   environment4 = "environment4",
 }
+
+export const containerIdForEnvironmentMap: Record<EnvironmentType, ContainerId> = {
+  [EnvironmentType.environment1]: "A",
+  [EnvironmentType.environment2]: "B",
+  [EnvironmentType.environment3]: "C",
+  [EnvironmentType.environment4]: "D"
+};
+
+export const environmentForContainerId: Record<ContainerId, EnvironmentType> = {
+  A: EnvironmentType.environment1,
+  B: EnvironmentType.environment2,
+  C: EnvironmentType.environment3,
+  D: EnvironmentType.environment4
+};
 
 export interface Environment {
   type: EnvironmentType;


### PR DESCRIPTION
- put tray objects and pti score in output state
- eliminate save button
- auto-save output state to container
- live-update thumbnails when appropriate
- limit thumbnails to one per environment
- move `showTray` and `habitatFeatures` into `outputState`
- allow thumbnail navigation except when simulation is running
