### PR TITLE
turn off sim animation transition time when the sim is not running

### DIFF
--- a/src/components/simulation/simulation-view.tsx
+++ b/src/components/simulation/simulation-view.tsx
@@ -61,7 +61,7 @@ export const SimulationView: React.FC<IProps> = (props) => {
       />
       <TransitionGroup>
         { animations.map((animation, index) =>
-          <CSSTransition key={index} timeout={kSimulationOneWeekPeriodInMilliseconds} classNames="animation-item">
+          <CSSTransition key={index} timeout={isRunning ? kSimulationOneWeekPeriodInMilliseconds : 0} classNames="animation-item">
             <SimulationAnimation
               animation={animation}
               key={`animation-${index}`}


### PR DESCRIPTION
Turn off the fish animation transition time when the sim is not running.  This prevents fish from fading in over 3.67 seconds when toggling between thumbnails.