### PR TITLE
176917508 drag preview context

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -288,6 +288,7 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
       }
     });
     setOutputStateAndSave({ trayObjects: updatedTrayObjects });
+    setTraySelectionType(undefined);
   };
 
   const handleHabitatSelectFeature = (feature: HabitatFeatureType, value: boolean) => {

--- a/src/components/notebook/macro-animal-row.tsx
+++ b/src/components/notebook/macro-animal-row.tsx
@@ -40,7 +40,7 @@ export const MacroAnimalRow: React.FC<IProps> = (props) => {
           </div>
         : <div
             className={`empty-box ${traySelectionType ? "enabled" : ""} ${isOver ? "highlight" : ""}`}
-            style={{backgroundColor: sensitivity?.blockColor,
+            style={{backgroundColor: isOver ? sensitivity?.backgroundColor : sensitivity?.blockColor,
                     borderColor: isOver ? sensitivity?.graphColor : "#333333"}}
             onClick={() => onCategorizeAnimal(traySelectionType, trayAnimal?.type)}
           />

--- a/src/components/notebook/macro-panel.scss
+++ b/src/components/notebook/macro-panel.scss
@@ -39,6 +39,7 @@
         border: solid 2px $gray-dark;
         border-radius: 5px;
         margin: 5px;
+        background-color: white;
 
         .animal-icon {
           height: 30px;
@@ -67,14 +68,6 @@
         &.enabled {
           pointer-events: auto;
           cursor: pointer;
-
-          &:hover {
-            border-style: solid;
-          }
-        }
-
-        &.highlight{
-          border-style: solid;
         }
       }
 

--- a/src/components/simulation/tray-image.scss
+++ b/src/components/simulation/tray-image.scss
@@ -21,6 +21,10 @@
         display: block;
       }
     }
+
+    &.dragging {
+      opacity: 0;
+    }
   }
 
   .tray-object-image-selectable {

--- a/src/components/simulation/tray-image.scss
+++ b/src/components/simulation/tray-image.scss
@@ -43,8 +43,4 @@
   left: 0;
   transform-origin: center;
   opacity: .5;
-
-  &.small {
-    height: 64px;
-  }
 }

--- a/src/components/simulation/tray-image.scss
+++ b/src/components/simulation/tray-image.scss
@@ -42,4 +42,9 @@
   top: 0;
   left: 0;
   transform-origin: center;
+  opacity: .5;
+
+  &.small {
+    height: 30px;
+  }
 }

--- a/src/components/simulation/tray-image.scss
+++ b/src/components/simulation/tray-image.scss
@@ -45,6 +45,6 @@
   opacity: .5;
 
   &.small {
-    height: 30px;
+    height: 64px;
   }
 }

--- a/src/components/simulation/tray-image.tsx
+++ b/src/components/simulation/tray-image.tsx
@@ -41,7 +41,7 @@ export const TrayImage: React.FC<IProps> = (props) => {
     }
     const boundingBoxDeltaX = (trayObject.boundingBoxWidth - trayObject.width) / 2;
     const boundingBoxDeltaY = (trayObject.boundingBoxHeight - trayObject.height) / 2;
-    let previewStyle = {};
+    let previewStyle: React.CSSProperties;
     const isLeaf = draggableLeafTypes.includes(trayObject.type as any);
     if (dragOverTray || isLeaf) {
       previewStyle = {
@@ -53,7 +53,7 @@ export const TrayImage: React.FC<IProps> = (props) => {
       const previewHeight = Math.min(kNonTrayPreviewHeight, trayObject.height);
       previewStyle = {
         height: previewHeight,
-        left: dragPosition.x - previewHeight / trayObject.height * trayObject.width / 2,
+        left: dragPosition.x - (previewHeight / trayObject.height) * trayObject.width / 2,
         top: dragPosition.y - previewHeight / 2,
       };
     }

--- a/src/components/simulation/tray-image.tsx
+++ b/src/components/simulation/tray-image.tsx
@@ -50,12 +50,14 @@ export const TrayImage: React.FC<IProps> = (props) => {
         transform: `rotate(${trayObject.rotation}deg)`
       };
     } else {
+      const previewHeight = Math.min(kNonTrayPreviewHeight, trayObject.height);
       previewStyle = {
-        left: dragPosition.x - kNonTrayPreviewHeight / trayObject.height * trayObject.width / 2,
-        top: dragPosition.y - kNonTrayPreviewHeight / 2,
+        height: previewHeight,
+        left: dragPosition.x - previewHeight / trayObject.height * trayObject.width / 2,
+        top: dragPosition.y - previewHeight / 2,
       };
     }
-    return <img style={previewStyle} src={item.dragImage} className={`preview ${(!dragOverTray && !isLeaf) ? "small" : ""}`} />;
+    return <img style={previewStyle} src={item.dragImage} className="preview" />;
   };
 
   const containerStyle = {left: trayObject.left, top: trayObject.top, width: trayObject.width, height: trayObject.height,

--- a/src/components/simulation/tray-image.tsx
+++ b/src/components/simulation/tray-image.tsx
@@ -17,11 +17,11 @@ interface IProps {
   trayObject: TrayObject;
   onTrayObjectSelect: (type: TrayType) => void;
   traySelectionType?: TrayType;
-  dragOverTray: boolean;
+  trayWrapper: HTMLDivElement | null;
 }
 
 export const TrayImage: React.FC<IProps> = (props) => {
-  const { trayObject, onTrayObjectSelect, traySelectionType, dragOverTray } = props;
+  const { trayObject, onTrayObjectSelect, traySelectionType, trayWrapper } = props;
   const TrayObjectImage = trayObject.image;
 
   const [{isDragging, dragSourcePosition, dragPosition}, drag ] = useDrag({
@@ -43,7 +43,12 @@ export const TrayImage: React.FC<IProps> = (props) => {
     const boundingBoxDeltaY = (trayObject.boundingBoxHeight - trayObject.height) / 2;
     let previewStyle: React.CSSProperties;
     const isLeaf = draggableLeafTypes.includes(trayObject.type as any);
-    if (dragOverTray || isLeaf) {
+
+    const trayRect = trayWrapper?.getBoundingClientRect();
+    const overTray = trayRect && (dragPosition.x >= trayRect.x && dragPosition.x <= (trayRect.x + trayRect.width) &&
+                     dragPosition.y >= trayRect.y && dragPosition.y <= (trayRect.x + trayRect.height));
+
+    if (overTray || isLeaf) {
       previewStyle = {
         left: dragSourcePosition.x + boundingBoxDeltaX - kOutlineOffset,
         top: dragSourcePosition.y + boundingBoxDeltaY - kOutlineOffset,

--- a/src/components/simulation/tray-image.tsx
+++ b/src/components/simulation/tray-image.tsx
@@ -11,7 +11,7 @@ import "./tray-image.scss";
 // corner. This ends up being about 5 pixels for all tray objects. Technically it could be computed
 // by hand for ALL tray objects, but subtracting 5 pixels works pretty well in practice.
 const kOutlineOffset = 5;
-const kNonTrayPreviewHeight = 30;
+const kNonTrayPreviewHeight = 64;
 
 interface IProps {
   trayObject: TrayObject;

--- a/src/components/simulation/tray-image.tsx
+++ b/src/components/simulation/tray-image.tsx
@@ -11,7 +11,7 @@ import "./tray-image.scss";
 // corner. This ends up being about 5 pixels for all tray objects. Technically it could be computed
 // by hand for ALL tray objects, but subtracting 5 pixels works pretty well in practice.
 const kOutlineOffset = 5;
-const kNonTrayPreviewHeight = 64;
+const kNonTrayPreviewHeight = 48;
 
 interface IProps {
   trayObject: TrayObject;
@@ -69,7 +69,7 @@ export const TrayImage: React.FC<IProps> = (props) => {
       {isDragging && <PreviewImage />}
       <div style={containerStyle} className="tray-image-container">
         <TrayObjectImage
-          className={`tray-object-image ${isDragging || trayObject.type === traySelectionType ? "highlight" : ""}`}
+          className={`tray-object-image ${trayObject.type === traySelectionType ? "highlight" : ""} ${isDragging ? "dragging" : ""}`}
           style={imageStyle}
         />
         <svg version="1.1" className="tray-object-image-selectable" style={imageStyle}>

--- a/src/components/simulation/tray.scss
+++ b/src/components/simulation/tray.scss
@@ -4,14 +4,18 @@
   position: absolute;
   top: 6px;
   left: -16px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   width: 444px;
   height: 342px;
   opacity: 1;
   transition: opacity 250ms;
+
+  .tray-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+  }
 
   &.hidden {
     pointer-events: none;

--- a/src/components/simulation/tray.tsx
+++ b/src/components/simulation/tray.tsx
@@ -21,7 +21,7 @@ interface IProps {
 export const Tray: React.FC<IProps> = (props) => {
   const { trayObjects, hidden, onTrayObjectSelect, onHideTray, traySelectionType, onTrayObjectMove } = props;
 
-  const [, drop] = useDrop({
+  const [{ isOver }, drop] = useDrop({
     accept: [...draggableAnimalTypes, ...draggableLeafTypes],
     drop: (item: any, monitor) => {
       const delta = monitor.getDifferenceFromInitialOffset();
@@ -29,6 +29,9 @@ export const Tray: React.FC<IProps> = (props) => {
       const top = Math.round(item.top + delta?.y);
       onTrayObjectMove(item.trayIndex, left, top);
     },
+    collect: monitor => ({
+      isOver: !!monitor.isOver(),
+    }),
   });
 
   return (
@@ -47,6 +50,7 @@ export const Tray: React.FC<IProps> = (props) => {
             trayObject={trayObject}
             onTrayObjectSelect={onTrayObjectSelect}
             traySelectionType={traySelectionType}
+            dragOverTray={isOver}
           />
         );
       })}

--- a/src/components/simulation/tray.tsx
+++ b/src/components/simulation/tray.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import t from "../../utils/translation/translate";
 import SortingTray from "../../assets/sorting-tray.svg";
 import CloseIcon from "../../assets/close-icon.svg";
@@ -20,8 +20,9 @@ interface IProps {
 
 export const Tray: React.FC<IProps> = (props) => {
   const { trayObjects, hidden, onTrayObjectSelect, onHideTray, traySelectionType, onTrayObjectMove } = props;
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
-  const [{ isOver }, drop] = useDrop({
+  const [, drop] = useDrop({
     accept: [...draggableAnimalTypes, ...draggableLeafTypes],
     drop: (item: any, monitor) => {
       const delta = monitor.getDifferenceFromInitialOffset();
@@ -29,31 +30,30 @@ export const Tray: React.FC<IProps> = (props) => {
       const top = Math.round(item.top + delta?.y);
       onTrayObjectMove(item.trayIndex, left, top);
     },
-    collect: monitor => ({
-      isOver: !!monitor.isOver(),
-    }),
   });
 
   return (
     <div className={`tray ${hidden ? "hidden" : ""}`} ref={drop}>
-      <SortingTray />
-      <div className="header">
-        <div className="title">{t("SORTINGTRAY")}</div>
-        <button className="close" onClick={onHideTray} aria-label={t("BUTTON.CLOSE")}>
-          <CloseIcon />
-        </button>
+      <div className="tray-wrapper" ref={wrapperRef}>
+        <SortingTray />
+        <div className="header">
+          <div className="title">{t("SORTINGTRAY")}</div>
+          <button className="close" onClick={onHideTray} aria-label={t("BUTTON.CLOSE")}>
+            <CloseIcon />
+          </button>
+        </div>
+        { trayObjects.map((trayObject, index) => {
+          return ((trayObject.count > 0 && !trayObject.collected) &&
+            <TrayImage
+              key={`animal-image-${index}`}
+              trayObject={trayObject}
+              onTrayObjectSelect={onTrayObjectSelect}
+              traySelectionType={traySelectionType}
+              trayWrapper={wrapperRef.current}
+            />
+          );
+        })}
       </div>
-      { trayObjects.map((trayObject, index) => {
-        return ((trayObject.count > 0 && !trayObject.collected) &&
-          <TrayImage
-            key={`animal-image-${index}`}
-            trayObject={trayObject}
-            onTrayObjectSelect={onTrayObjectSelect}
-            traySelectionType={traySelectionType}
-            dragOverTray={isOver}
-          />
-        );
-      })}
     </div>
   );
 };


### PR DESCRIPTION
This PR updates the tray dragging so that drag preview is different depending on if we are dragging over the tray or dragging outside of the tray.  
- When over the tray, the drag preview should be at 100% with the same rotation as we see in the tray and a drag preview offset is based on where the user clicked.  
- When the drag is NOT over the tray, the drag preview should have no rotation, a max height of 48, and the cursor should be at the center of the drag preview.

Additional improvements:
- notebook hover matches spec
- deselect animal when drag finishes
- hide image when dragging

NOTE: keep an eye out for any sluggishness when dragging.  Dragging is sluggish on my local system but seems to be sluggish both before/after this PR.

Can preview here:
https://leaf-pack.concord.org/branch/drag-preview-context/

![drag-preview](https://user-images.githubusercontent.com/5126913/108390593-ae32e880-71c5-11eb-8bef-e12b06cfe4b0.gif)
