### PR TITLE
Fix react warning on drag [#177011402]

### DIFF
--- a/src/components/simulation/tray-image-preview.test.tsx
+++ b/src/components/simulation/tray-image-preview.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { TrayImagePreview } from "./tray-image-preview";
+import { AnimalType, TrayObject } from "../../utils/sim-utils";
+
+let callCount = 0;
+jest.mock("react-dnd-preview", () => ({
+  // display is false on first call, true after that
+  usePreview: () => ({ display: callCount++ > 0, item: {} })
+}));
+
+describe("TrayImagePreview component", () => {
+
+  const trayWrapper: any = {
+    getBoundingClientRect() {
+      return { x: 0, y: 0, width: 100, height: 100 };
+    }
+  };
+
+  const trayObject: TrayObject = {
+    type: AnimalType.caddisFly,
+    trayIndex: 0,
+    count: 1,
+    collected: false,
+    left: 100,
+    top: 100,
+    width: 50,
+    height: 50,
+    boundingBoxWidth: 60,
+    boundingBoxHeight: 60,
+    rotation: 0,
+    image: null,
+    dragImage: null,
+    selectionPath: "",
+    zIndex: 1
+  };
+
+  it("doesn't render with no display", () => {
+    render(<TrayImagePreview trayWrapper={null} trayObject={trayObject}
+              dragSourcePosition={null} dragPosition={null} />);
+    expect(screen.queryByTestId("preview")).toBeNull();
+  });
+
+  it("doesn't render with no drag position", () => {
+    render(<TrayImagePreview trayWrapper={null} trayObject={trayObject}
+              dragSourcePosition={null} dragPosition={null} />);
+    expect(screen.queryByTestId("preview")).toBeNull();
+  });
+
+  it("renders with no tray", () => {
+    render(<TrayImagePreview trayWrapper={null} trayObject={trayObject}
+              dragSourcePosition={{ x: 10, y: 10 }} dragPosition={{ x: 20, y: 20 }} />);
+    expect(screen.getByTestId("preview")).toBeInTheDocument();
+  });
+
+  it("renders when over tray", () => {
+    render(<TrayImagePreview trayWrapper={trayWrapper} trayObject={trayObject}
+              dragSourcePosition={{ x: 10, y: 10 }} dragPosition={{ x: 20, y: 20 }} />);
+    expect(screen.getByTestId("preview")).toBeInTheDocument();
+  });
+
+  it("renders when not over tray", () => {
+    render(<TrayImagePreview trayWrapper={trayWrapper} trayObject={trayObject}
+              dragSourcePosition={{ x: 1000, y: 1000 }} dragPosition={{ x: 2000, y: 2000 }} />);
+    expect(screen.getByTestId("preview")).toBeInTheDocument();
+  });
+});

--- a/src/components/simulation/tray-image-preview.tsx
+++ b/src/components/simulation/tray-image-preview.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { XYCoord } from "react-dnd";
+import { usePreview } from "react-dnd-preview";
+import { draggableLeafTypes, TrayObject } from "../../utils/sim-utils";
+
+// the drag ref is attached to the clickable outline which is a little smaller than the actual
+// SVG dimensions which include the highlight border. To get the drag preview to display properly
+// we need to take into account how much the clickable outline is offset from the SVG upper-left
+// corner. This ends up being about 5 pixels for all tray objects. Technically it could be computed
+// by hand for ALL tray objects, but subtracting 5 pixels works pretty well in practice.
+const kOutlineOffset = 5;
+const kNonTrayPreviewHeight = 48;
+
+interface IProps {
+  trayWrapper: HTMLDivElement | null;
+  trayObject: TrayObject;
+  dragSourcePosition: XYCoord | null;
+  dragPosition: XYCoord | null;
+}
+export const TrayImagePreview: React.FC<IProps> = ({ trayWrapper, trayObject, dragSourcePosition, dragPosition }) => {
+  const {display, item} = usePreview();
+  if (!display || !dragSourcePosition || !dragPosition) {
+    return null;
+  }
+  const boundingBoxDeltaX = (trayObject.boundingBoxWidth - trayObject.width) / 2;
+  const boundingBoxDeltaY = (trayObject.boundingBoxHeight - trayObject.height) / 2;
+  let previewStyle: React.CSSProperties;
+  const isLeaf = draggableLeafTypes.includes(trayObject.type as any);
+
+  const trayRect = trayWrapper?.getBoundingClientRect();
+  const overTray = trayRect && (dragPosition.x >= trayRect.x && dragPosition.x <= (trayRect.x + trayRect.width) &&
+                    dragPosition.y >= trayRect.y && dragPosition.y <= (trayRect.x + trayRect.height));
+
+  if (overTray || isLeaf) {
+    previewStyle = {
+      left: dragSourcePosition.x + boundingBoxDeltaX - kOutlineOffset,
+      top: dragSourcePosition.y + boundingBoxDeltaY - kOutlineOffset,
+      transform: `rotate(${trayObject.rotation}deg)`
+    };
+  } else {
+    const previewHeight = Math.min(kNonTrayPreviewHeight, trayObject.height);
+    previewStyle = {
+      height: previewHeight,
+      left: dragPosition.x - (previewHeight / trayObject.height) * trayObject.width / 2,
+      top: dragPosition.y - previewHeight / 2,
+    };
+  }
+  return <img style={previewStyle} src={item.dragImage} className="preview" data-testid="preview" />;
+};

--- a/src/components/simulation/tray-image.tsx
+++ b/src/components/simulation/tray-image.tsx
@@ -1,17 +1,9 @@
 import React from "react";
-import { TrayType, TrayObject, draggableLeafTypes } from "../../utils/sim-utils";
 import { useDrag } from "react-dnd";
-import { usePreview } from "react-dnd-preview";
+import { TrayImagePreview } from "./tray-image-preview";
+import { TrayType, TrayObject } from "../../utils/sim-utils";
 
 import "./tray-image.scss";
-
-// the drag ref is attached to the clickable outline which is a little smaller than the actual
-// SVG dimensions which include the highlight border. To get the drag preview to display properly
-// we need to take into account how much the clickable outline is offset from the SVG upper-left
-// corner. This ends up being about 5 pixels for all tray objects. Technically it could be computed
-// by hand for ALL tray objects, but subtracting 5 pixels works pretty well in practice.
-const kOutlineOffset = 5;
-const kNonTrayPreviewHeight = 48;
 
 interface IProps {
   trayObject: TrayObject;
@@ -24,7 +16,7 @@ export const TrayImage: React.FC<IProps> = (props) => {
   const { trayObject, onTrayObjectSelect, traySelectionType, trayWrapper } = props;
   const TrayObjectImage = trayObject.image;
 
-  const [{isDragging, dragSourcePosition, dragPosition}, drag ] = useDrag({
+  const [{isDragging, ...otherDragProps}, drag ] = useDrag({
     item: { type: trayObject.type, trayIndex: trayObject.trayIndex, dragImage: trayObject.dragImage,
             left: trayObject.left, top: trayObject.top },
     collect: monitor => ({
@@ -34,44 +26,14 @@ export const TrayImage: React.FC<IProps> = (props) => {
     }),
   });
 
-  const PreviewImage = () => {
-    const {display, item} = usePreview();
-    if (!display || !dragSourcePosition || !dragPosition) {
-      return null;
-    }
-    const boundingBoxDeltaX = (trayObject.boundingBoxWidth - trayObject.width) / 2;
-    const boundingBoxDeltaY = (trayObject.boundingBoxHeight - trayObject.height) / 2;
-    let previewStyle: React.CSSProperties;
-    const isLeaf = draggableLeafTypes.includes(trayObject.type as any);
-
-    const trayRect = trayWrapper?.getBoundingClientRect();
-    const overTray = trayRect && (dragPosition.x >= trayRect.x && dragPosition.x <= (trayRect.x + trayRect.width) &&
-                     dragPosition.y >= trayRect.y && dragPosition.y <= (trayRect.x + trayRect.height));
-
-    if (overTray || isLeaf) {
-      previewStyle = {
-        left: dragSourcePosition.x + boundingBoxDeltaX - kOutlineOffset,
-        top: dragSourcePosition.y + boundingBoxDeltaY - kOutlineOffset,
-        transform: `rotate(${trayObject.rotation}deg)`
-      };
-    } else {
-      const previewHeight = Math.min(kNonTrayPreviewHeight, trayObject.height);
-      previewStyle = {
-        height: previewHeight,
-        left: dragPosition.x - (previewHeight / trayObject.height) * trayObject.width / 2,
-        top: dragPosition.y - previewHeight / 2,
-      };
-    }
-    return <img style={previewStyle} src={item.dragImage} className="preview" />;
-  };
-
   const containerStyle = {left: trayObject.left, top: trayObject.top, width: trayObject.width, height: trayObject.height,
                           zIndex: trayObject.zIndex};
   const imageStyle = {width: trayObject.width, height: trayObject.height, transform: `rotate(${trayObject.rotation}deg)`};
 
   return (
     <>
-      {isDragging && <PreviewImage />}
+      {isDragging &&
+        <TrayImagePreview trayWrapper={trayWrapper} trayObject={trayObject} {...otherDragProps} />}
       <div style={containerStyle} className="tray-image-container">
         <TrayObjectImage
           className={`tray-object-image ${trayObject.type === traySelectionType ? "highlight" : ""} ${isDragging ? "dragging" : ""}`}


### PR DESCRIPTION
Move definition of preview component to its own module so it's not being redefined on every render.