### PR TITLE
176971824 chem sliders

### DIFF
--- a/src/assets/disk-0.svg
+++ b/src/assets/disk-0.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g fill="none" fill-rule="evenodd">
+        <g>
+            <g>
+                <path fill="#333" fill-rule="nonzero" d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0z" transform="translate(-584 -1214) translate(584 1214)"/>
+                <path fill="#FFF" fill-rule="nonzero" d="M12 .5C18.351.5 23.5 5.649 23.5 12S18.351 23.5 12 23.5.5 18.351.5 12 5.649.5 12 .5z" transform="translate(-584 -1214) translate(584 1214)"/>
+                <path fill="#333" d="M12 12V0C5.373 0 0 5.373 0 12h12z" transform="translate(-584 -1214) translate(584 1214)"/>
+                <path fill="#333" d="M24 24V12c-6.627 0-12 5.373-12 12h12z" transform="translate(-584 -1214) translate(584 1214) rotate(180 18 18)"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/assets/disk-100.svg
+++ b/src/assets/disk-100.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g fill="none" fill-rule="evenodd">
+        <g>
+            <g>
+                <path fill="#999" fill-rule="nonzero" d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0z" transform="translate(-652 -1214) translate(652 1214)"/>
+                <path fill="#FFF" fill-rule="nonzero" d="M12 .5C18.351.5 23.5 5.649 23.5 12S18.351 23.5 12 23.5.5 18.351.5 12 5.649.5 12 .5z" transform="translate(-652 -1214) translate(652 1214)"/>
+                <path fill="#999" d="M12 12V0C5.373 0 0 5.373 0 12h12z" transform="translate(-652 -1214) translate(652 1214)"/>
+                <path fill="#999" d="M24 24V12c-6.627 0-12 5.373-12 12h12z" transform="translate(-652 -1214) translate(652 1214) rotate(180 18 18)"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/assets/disk-40.svg
+++ b/src/assets/disk-40.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <g fill="none" fill-rule="evenodd">
+        <g>
+            <g>
+                <path fill="#646464" fill-rule="nonzero" d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0z" transform="translate(-618 -1214) translate(618 1214)"/>
+                <path fill="#FFF" fill-rule="nonzero" d="M12 .5C18.351.5 23.5 5.649 23.5 12S18.351 23.5 12 23.5.5 18.351.5 12 5.649.5 12 .5z" transform="translate(-618 -1214) translate(618 1214)"/>
+                <path fill="#646464" d="M12 12V0C5.373 0 0 5.373 0 12h12z" transform="translate(-618 -1214) translate(618 1214)"/>
+                <path fill="#646464" d="M24 24V12c-6.627 0-12 5.373-12 12h12z" transform="translate(-618 -1214) translate(618 1214) rotate(180 18 18)"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -307,15 +307,14 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
     setOutputStateAndSave({ habitatFeatures });
   };
 
-  const handleUpdateTestResult = (type: ChemTestType, completedStep: number) => {
+  const handleUpdateTestResult = (type: ChemTestType, completedStep: number, value?: number) => {
     const updatedChemistryTestResults = chemistryTestResults.map((result: ChemistryTestResult) => {
       if (result.type === type) {
         const updatedResult = { ...result };
         updatedResult.stepsComplete = completedStep;
         const currentTest = chemistryTests.find((test) => test.type === type);
-        if (completedStep === currentTest?.steps.length) {
-          // TODO: user defines value, pick random number for now
-          updatedResult.value = currentTest.values[getRandomInteger(0, currentTest.values.length - 1)].value;
+        if (completedStep === currentTest?.steps.length && value !== undefined) {
+          updatedResult.value = value;
         }
         return updatedResult;
       } else {

--- a/src/components/control-panel/sunny-day-slider.scss
+++ b/src/components/control-panel/sunny-day-slider.scss
@@ -14,6 +14,6 @@
 
   .label {
     margin-left: 4px;
-    color: $gray-dark
+    color: $gray-dark;
   }
 }

--- a/src/components/notebook/chem-results.scss
+++ b/src/components/notebook/chem-results.scss
@@ -12,6 +12,11 @@
     height: 24px;
     width: 408px;
     background-color: $chemistry-blue-dark1;
+
+    .category-label {
+      width: 50%;
+      text-align: center;
+    }
   }
 
   .results {

--- a/src/components/notebook/chem-results.tsx
+++ b/src/components/notebook/chem-results.tsx
@@ -16,7 +16,7 @@ export const ChemResults: React.FC<IProps> = (props) => {
     <div className="chem-results">
       <div className="header">
         {t("CHEM.TEST")}
-        {t("CHEM.RESULT")}
+        {t("CHEM.WATER.RESULT")}
       </div>
       <div className="results">
         {chemistryTests.map((test, index) => {

--- a/src/components/notebook/chem-results.tsx
+++ b/src/components/notebook/chem-results.tsx
@@ -15,8 +15,8 @@ export const ChemResults: React.FC<IProps> = (props) => {
   return (
     <div className="chem-results">
       <div className="header">
-        {t("CHEM.TEST")}
-        {t("CHEM.WATER.RESULT")}
+        <div className="category-label">{t("CHEM.TEST")}</div>
+        <div className="category-label">{t("CHEM.WATER.RESULT")}</div>
       </div>
       <div className="results">
         {chemistryTests.map((test, index) => {

--- a/src/components/notebook/chem-results.tsx
+++ b/src/components/notebook/chem-results.tsx
@@ -22,7 +22,7 @@ export const ChemResults: React.FC<IProps> = (props) => {
         {chemistryTests.map((test, index) => {
           const testResult = chemistryTestResults.find((result) => result.type === test.type);
           const complete = testResult?.stepsComplete === test.steps.length;
-          const testValue = test.values.find((val) => val.value === testResult?.value);
+          const testValue = test.results.find((res) => res.value === testResult?.value);
           const ratingType = testValue?.rating;
           const rating = chemTestRatings.find((r) => r.type === ratingType);
           const started = testResult ? testResult.stepsComplete > 0 : false;

--- a/src/components/notebook/chem-test-slider.scss
+++ b/src/components/notebook/chem-test-slider.scss
@@ -1,0 +1,46 @@
+@import "../vars.scss";
+
+.chem-slider {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 150px;
+
+  .slider-values {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .value-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      font-weight: bold;
+      width: 25px;
+
+      &.selected {
+        font-size: 16px;
+        font-weight: 900;
+      }
+
+      .bubble {
+        width: 25px;
+        height: 25px;
+        border-radius: 50%;
+        border: solid 2px white;
+        box-sizing: border-box;
+      }
+    }
+  }
+
+  .slider {
+    margin-right: 8px;
+  }
+
+  .label {
+    margin-left: 4px;
+    color: $gray-dark
+  }
+}

--- a/src/components/notebook/chem-test-slider.scss
+++ b/src/components/notebook/chem-test-slider.scss
@@ -10,6 +10,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    position: relative;
 
     .value-container {
       display: flex;
@@ -32,6 +33,15 @@
         border: solid 2px white;
         box-sizing: border-box;
       }
+    }
+
+    .slider-units {
+      position: absolute;
+      left: calc(100% + 5px);
+      top: 3px;
+      font-size: 12px;
+      font-weight: bold;
+      font-style: italic;
     }
   }
 

--- a/src/components/notebook/chem-test-slider.scss
+++ b/src/components/notebook/chem-test-slider.scss
@@ -51,6 +51,6 @@
 
   .label {
     margin-left: 4px;
-    color: $gray-dark
+    color: $gray-dark;
   }
 }

--- a/src/components/notebook/chem-test-slider.tsx
+++ b/src/components/notebook/chem-test-slider.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import Slider from "@material-ui/core/Slider";
+import { ChemTestValue } from "../../utils/chem-utils";
+import IconHorizontalHandle from "../../assets/icon-slider-horizontal.svg";
+
+import "./chem-test-slider.scss";
+import "../../components/control-panel/slider.scss";
+
+const kSliderValWidth = 25;
+
+interface IProps {
+  onChangeSlider: (event: any, value: number) => void;
+  sliderValue: number;
+  testValues: ChemTestValue[];
+}
+
+export const ChemTestSlider: React.FC<IProps> = (props) => {
+  const { sliderValue, onChangeSlider, testValues } = props;
+  const sliderMarks = testValues.map((val, index) => {return ({value: index});});
+  return (
+    <div className="chem-slider" data-testid="chem-slider">
+      <div className="slider-values">
+        { testValues.map((val, index) =>
+          <div className={`value-container ${sliderValue === index ? "selected" : ""}`} key={`value-${val.value}`}>
+            {val.value}
+            <div className="bubble" style={{backgroundColor: val.color, borderColor: sliderValue === index ? "black" : "white"}}>
+              {val.icon && <val.icon className="slider-icon" width={21} />}
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="slider" style={{width: kSliderValWidth * (testValues.length - 1)}}>
+        <Slider
+          classes={{thumb: "thumb" }}
+          min={0}
+          max={testValues.length - 1}
+          value={sliderValue}
+          step={1}
+          marks={sliderMarks}
+          onChange={onChangeSlider}
+          ThumbComponent={IconHorizontalHandle}
+          data-test="chem-test-slider"
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/notebook/chem-test-slider.tsx
+++ b/src/components/notebook/chem-test-slider.tsx
@@ -12,11 +12,13 @@ interface IProps {
   onChangeSlider: (event: any, value: number) => void;
   sliderValue: number;
   testValues: ChemTestValue[];
+  units: string;
 }
 
 export const ChemTestSlider: React.FC<IProps> = (props) => {
-  const { sliderValue, onChangeSlider, testValues } = props;
+  const { sliderValue, onChangeSlider, testValues, units } = props;
   const sliderMarks = testValues.map((val, index) => {return ({value: index});});
+
   return (
     <div className="chem-slider" data-testid="chem-slider">
       <div className="slider-values">
@@ -28,6 +30,7 @@ export const ChemTestSlider: React.FC<IProps> = (props) => {
             </div>
           </div>
         )}
+        <div className="slider-units">{units}</div>
       </div>
       <div className="slider" style={{width: kSliderValWidth * (testValues.length - 1)}}>
         <Slider

--- a/src/components/notebook/chem-test.scss
+++ b/src/components/notebook/chem-test.scss
@@ -35,6 +35,10 @@
 
     .test-content {
       width: 240px;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: flex-end;
     }
   }
 

--- a/src/components/notebook/chem-test.scss
+++ b/src/components/notebook/chem-test.scss
@@ -47,10 +47,11 @@
     }
   }
 
-  .step-buttons {
+  .step-buttons-results {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    height: 186px;
 
     .step-button {
       position: relative;

--- a/src/components/notebook/chem-test.scss
+++ b/src/components/notebook/chem-test.scss
@@ -30,15 +30,20 @@
   .test-container {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     margin-top: 10px;
 
     .test-content {
       width: 240px;
-      height: 100%;
       display: flex;
+      flex-direction: column;
       justify-content: center;
-      align-items: flex-end;
+      align-items: center;
+
+      .image-stack {
+        height: 100px;
+        width: 100%;
+      }
     }
   }
 

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -17,12 +17,13 @@ interface IProps {
 export const ChemTest: React.FC<IProps> = (props) => {
   const { chemistryTest, testIndex, chemistryTestResults, onUpdateTestResult } = props;
   const testResult = chemistryTestResults.find((result) => result.type === chemistryTest.type);
-  console.log(testResult);
   const stepsComplete = testResult?.stepsComplete ?? 0;
-  const currentStep = chemistryTest.steps[Math.min(stepsComplete, chemistryTest.steps.length - 1)];
+  const currentStep = stepsComplete > 0
+    ? chemistryTest.steps[Math.min(stepsComplete - 1, chemistryTest.steps.length - 1)]
+    : undefined;
   const testValueIndex = testResult?.value
-   ? chemistryTest.values.findIndex((val) => val.value === testResult.value)
-   : 0;
+    ? chemistryTest.values.findIndex((val) => val.value === testResult.value)
+    : 0;
 
   const handleChangeSlider = (event: any, value: number) => {
     onUpdateTestResult(chemistryTest.type, chemistryTest.steps.length, chemistryTest.values[value].value);
@@ -36,12 +37,12 @@ export const ChemTest: React.FC<IProps> = (props) => {
       </div>
       <div className="test-container">
         <div className="test-content">
-          {(currentStep.type === StepType.resultSlider || currentStep.type === StepType.animation) &&
+          {(!currentStep || currentStep?.type === StepType.resultSlider || currentStep?.type === StepType.animation) &&
             <div className="image-stack">
-              {`${currentStep.label} image`}
+              {currentStep ? `${currentStep.label} image` : "start"}
             </div>
           }
-          {currentStep.type === StepType.resultSlider &&
+          {currentStep?.type === StepType.resultSlider &&
             <ChemTestSlider
               onChangeSlider={handleChangeSlider}
               sliderValue={testValueIndex}
@@ -67,7 +68,7 @@ export const ChemTest: React.FC<IProps> = (props) => {
               }
             </button>
           )}
-          {testResult && currentStep.type === StepType.resultSlider &&
+          {testResult && currentStep?.type === StepType.resultSlider &&
             <InputResult
               chemistryTest={chemistryTest}
               chemistryTestResult={testResult}

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -22,11 +22,11 @@ export const ChemTest: React.FC<IProps> = (props) => {
     ? chemistryTest.steps[Math.min(stepsComplete - 1, chemistryTest.steps.length - 1)]
     : undefined;
   const testValueIndex = testResult?.value
-    ? chemistryTest.values.findIndex((val) => val.value === testResult.value)
+    ? chemistryTest.results.findIndex((res) => res.value === testResult.value)
     : 0;
 
-  const handleChangeSlider = (event: any, value: number) => {
-    onUpdateTestResult(chemistryTest.type, chemistryTest.steps.length, chemistryTest.values[value].value);
+  const handleChangeSlider = (event: any, val: number) => {
+    onUpdateTestResult(chemistryTest.type, chemistryTest.steps.length, chemistryTest.results[val].value);
   };
 
   return (
@@ -46,7 +46,7 @@ export const ChemTest: React.FC<IProps> = (props) => {
             <ChemTestSlider
               onChangeSlider={handleChangeSlider}
               sliderValue={testValueIndex}
-              testValues={chemistryTest.values}
+              testValues={chemistryTest.results}
               units={chemistryTest.units}
             />
           }

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { ChemistryTest, ChemTestType, ChemistryTestResult } from "../../utils/chem-utils";
+import { ChemistryTest, ChemTestType, ChemistryTestResult, StepType } from "../../utils/chem-utils";
+import { ChemTestSlider } from "./chem-test-slider";
 import CheckIcon from "../../assets/check-icon.svg";
 import t from "../../utils/translation/translate";
 
@@ -9,13 +10,19 @@ interface IProps {
   chemistryTest: ChemistryTest;
   testIndex: number;
   chemistryTestResults: ChemistryTestResult[];
-  onUpdateTestResult: (type: ChemTestType, completedStep: number) => void;
+  onUpdateTestResult: (type: ChemTestType, completedStep: number, value?: number) => void;
 }
 
 export const ChemTest: React.FC<IProps> = (props) => {
   const { chemistryTest, testIndex, chemistryTestResults, onUpdateTestResult } = props;
   const testResult = chemistryTestResults.find((result) => result.type === chemistryTest.type);
   const stepsComplete = testResult?.stepsComplete ?? 0;
+  const currentStep = chemistryTest.steps[Math.min(stepsComplete, chemistryTest.steps.length - 1)];
+
+  const handleChangeSlider = (event: any, value: number) => {
+    onUpdateTestResult(chemistryTest.type, chemistryTest.steps.length, chemistryTest.values[value].value);
+  };
+
   return (
     <div className="chem-test">
       <div className="header">
@@ -23,7 +30,15 @@ export const ChemTest: React.FC<IProps> = (props) => {
         {`${chemistryTest.label} ${t("CHEM.TEST")}`}
       </div>
       <div className="test-container">
-        <div className="test-content"/>
+        <div className="test-content">
+        { currentStep.type === StepType.resultSlider &&
+          <ChemTestSlider
+            onChangeSlider={handleChangeSlider}
+            sliderValue={chemistryTest.values.findIndex((val) => val.value === testResult?.value) || 0}
+            testValues={chemistryTest.values}
+          />
+        }
+        </div>
         <div className="step-buttons">
           { chemistryTest.steps.map((step, index) =>
             <button

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ChemistryTest, ChemTestType, ChemistryTestResult, StepType } from "../../utils/chem-utils";
 import { ChemTestSlider } from "./chem-test-slider";
+import { InputResult } from "./input-result";
 import CheckIcon from "../../assets/check-icon.svg";
 import t from "../../utils/translation/translate";
 
@@ -16,6 +17,7 @@ interface IProps {
 export const ChemTest: React.FC<IProps> = (props) => {
   const { chemistryTest, testIndex, chemistryTestResults, onUpdateTestResult } = props;
   const testResult = chemistryTestResults.find((result) => result.type === chemistryTest.type);
+  console.log(testResult);
   const stepsComplete = testResult?.stepsComplete ?? 0;
   const currentStep = chemistryTest.steps[Math.min(stepsComplete, chemistryTest.steps.length - 1)];
   const testValueIndex = testResult?.value
@@ -34,12 +36,12 @@ export const ChemTest: React.FC<IProps> = (props) => {
       </div>
       <div className="test-container">
         <div className="test-content">
-          { (currentStep.type === StepType.resultSlider || currentStep.type === StepType.animation) &&
+          {(currentStep.type === StepType.resultSlider || currentStep.type === StepType.animation) &&
             <div className="image-stack">
               {`${currentStep.label} image`}
             </div>
           }
-          { currentStep.type === StepType.resultSlider &&
+          {currentStep.type === StepType.resultSlider &&
             <ChemTestSlider
               onChangeSlider={handleChangeSlider}
               sliderValue={testValueIndex}
@@ -48,8 +50,8 @@ export const ChemTest: React.FC<IProps> = (props) => {
             />
           }
         </div>
-        <div className="step-buttons">
-          { chemistryTest.steps.map((step, index) =>
+        <div className="step-buttons-results">
+          {chemistryTest.steps.map((step, index) =>
             <button
               className={`step-button ${index > stepsComplete ? "disabled" : ""} ${index < stepsComplete ? "finished" : ""}`}
               key={`${chemistryTest.type}-step-button-${index}`}
@@ -65,6 +67,12 @@ export const ChemTest: React.FC<IProps> = (props) => {
               }
             </button>
           )}
+          {testResult && currentStep.type === StepType.resultSlider &&
+            <InputResult
+              chemistryTest={chemistryTest}
+              chemistryTestResult={testResult}
+            />
+          }
         </div>
       </div>
     </div>

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -18,6 +18,9 @@ export const ChemTest: React.FC<IProps> = (props) => {
   const testResult = chemistryTestResults.find((result) => result.type === chemistryTest.type);
   const stepsComplete = testResult?.stepsComplete ?? 0;
   const currentStep = chemistryTest.steps[Math.min(stepsComplete, chemistryTest.steps.length - 1)];
+  const testValueIndex = testResult?.value
+   ? chemistryTest.values.findIndex((val) => val.value === testResult.value)
+   : 0;
 
   const handleChangeSlider = (event: any, value: number) => {
     onUpdateTestResult(chemistryTest.type, chemistryTest.steps.length, chemistryTest.values[value].value);
@@ -31,13 +34,19 @@ export const ChemTest: React.FC<IProps> = (props) => {
       </div>
       <div className="test-container">
         <div className="test-content">
-        { currentStep.type === StepType.resultSlider &&
-          <ChemTestSlider
-            onChangeSlider={handleChangeSlider}
-            sliderValue={chemistryTest.values.findIndex((val) => val.value === testResult?.value) || 0}
-            testValues={chemistryTest.values}
-          />
-        }
+          { (currentStep.type === StepType.resultSlider || currentStep.type === StepType.animation) &&
+            <div className="image-stack">
+              {`${currentStep.label} image`}
+            </div>
+          }
+          { currentStep.type === StepType.resultSlider &&
+            <ChemTestSlider
+              onChangeSlider={handleChangeSlider}
+              sliderValue={testValueIndex}
+              testValues={chemistryTest.values}
+              units={chemistryTest.units}
+            />
+          }
         </div>
         <div className="step-buttons">
           { chemistryTest.steps.map((step, index) =>

--- a/src/components/notebook/chemistry-panel.tsx
+++ b/src/components/notebook/chemistry-panel.tsx
@@ -8,7 +8,7 @@ import "./chemistry-panel.scss";
 
 interface IProps {
   chemistryTestResults: ChemistryTestResult[];
-  onUpdateTestResult: (type: ChemTestType, completedStep: number) => void;
+  onUpdateTestResult: (type: ChemTestType, completedStep: number, value?: number) => void;
   isRunning: boolean;
 }
 

--- a/src/components/notebook/input-result.scss
+++ b/src/components/notebook/input-result.scss
@@ -1,0 +1,39 @@
+@import "../vars.scss";
+
+.input-result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: auto;
+
+  .current-result {
+    width: 164px;
+    height: 36px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: $chemistry-blue;
+
+    .test-result {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 63px;
+      height: 23px;
+      border-radius: 4px;
+      background-color: white;
+      margin-right: 3px;
+    }
+
+    .test-rating {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 74px;
+      height: 23px;
+      border-radius: 4px;
+      margin-left: 3px;
+      background-color: $macro-score-pink;
+    }
+  }
+}

--- a/src/components/notebook/input-result.tsx
+++ b/src/components/notebook/input-result.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { ChemistryTest, ChemistryTestResult, chemTestRatings } from "../../utils/chem-utils";
+import t from "../../utils/translation/translate";
+
+import "./input-result.scss";
+
+interface IProps {
+  chemistryTest: ChemistryTest;
+  chemistryTestResult: ChemistryTestResult;
+}
+
+export const InputResult: React.FC<IProps> = (props) => {
+  const { chemistryTest, chemistryTestResult } = props;
+  const testValue = chemistryTest.values.find((val) => val.value === chemistryTestResult?.value);
+  const ratingType = testValue?.rating;
+  const rating = chemTestRatings.find((r) => r.type === ratingType);
+  return (
+    <div className="input-result">
+      {t("CHEM.RESULT")}
+      <div className="current-result">
+        <div className="test-result">{`${chemistryTestResult?.value} ${chemistryTest.units}`}</div>
+        {rating && <div>=</div>}
+        {rating && <div className="test-rating" style={{backgroundColor: rating.color}}>{rating.label}</div>}
+      </div>
+    </div>
+  );
+};

--- a/src/components/notebook/input-result.tsx
+++ b/src/components/notebook/input-result.tsx
@@ -11,7 +11,7 @@ interface IProps {
 
 export const InputResult: React.FC<IProps> = (props) => {
   const { chemistryTest, chemistryTestResult } = props;
-  const testValue = chemistryTest.values.find((val) => val.value === chemistryTestResult?.value);
+  const testValue = chemistryTest.results.find((res) => res.value === chemistryTestResult?.value);
   const ratingType = testValue?.rating;
   const rating = chemTestRatings.find((r) => r.type === ratingType);
   return (

--- a/src/components/notebook/notebook.tsx
+++ b/src/components/notebook/notebook.tsx
@@ -21,7 +21,7 @@ interface IProps {
   onSelectFeature: (feature: HabitatFeatureType, selected: boolean) => void;
   onCategorizeAnimal: (trayType: TrayType | undefined, notebookType: TrayType | undefined) => void;
   chemistryTestResults: ChemistryTestResult[];
-  onUpdateTestResult: (type: ChemTestType, completedStep: number) => void;
+  onUpdateTestResult: (type: ChemTestType, completedStep: number, value?: number) => void;
   traySelectionType?: TrayType;
   isRunning: boolean;
 }

--- a/src/utils/chem-utils.ts
+++ b/src/utils/chem-utils.ts
@@ -1,3 +1,6 @@
+import Turbidity0 from "../assets/disk-0.svg";
+import Turbidity40 from "../assets/disk-40.svg";
+import Turbidity100 from "../assets/disk-100.svg";
 import t from "./translation/translate";
 
 export enum ChemTestType {
@@ -28,7 +31,14 @@ export const chemTestRatings: ChemTestRating[] = [
   {type: ChemTestRatingType.poor, label: t("CHEM.POOR"), color: "#ffacac"},
 ];
 
+export enum StepType {
+  animation = "animation",
+  resultSlider = "resultSlider",
+  tempDisplay = "tempDisplay",
+}
+
 export interface ChemTestStep {
+  type: StepType;
   label: string;
   content?: any; // TODO: what appears in the test (animation, slider, etc.)
 }
@@ -36,6 +46,8 @@ export interface ChemTestStep {
 export interface ChemTestValue {
   value: number;
   rating?: ChemTestRatingType;
+  color?: string;
+  icon?: any;
 }
 
 export interface ChemistryTest {
@@ -48,36 +60,40 @@ export interface ChemistryTest {
 
 export const chemistryTests: ChemistryTest[] = [
   { type: ChemTestType.airTemperature, label: t("CHEM.AIRTEMP.TEST"), units: t("CHEM.TEMP.UNIT"),
-    steps: [{label: t("CHEM.READ.THERMOMETER")}],
+    steps: [{type: StepType.tempDisplay, label: t("CHEM.READ.THERMOMETER")}],
     values: [{value: 14}, {value: 16}, {value: 18}, {value: 20}, {value: 22}, {value: 24}, {value: 26}, {value: 28},
              {value: 30}, {value: 32}, {value: 34}, {value: 36}, {value: 38}, {value: 40}],
   },
   { type: ChemTestType.waterTemperature, label: t("CHEM.WATERTEMP.TEST"), units: t("CHEM.TEMP.UNIT"),
-    steps: [{label: t("CHEM.COLLECT.SAMPLE")}, {label: t("CHEM.READ.THERMOMETER")}],
+    steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")},
+            {type: StepType.tempDisplay, label: t("CHEM.READ.THERMOMETER")}],
     values: [{value: 14}, {value: 16}, {value: 18}, {value: 20}, {value: 22}, {value: 24}, {value: 26}, {value: 28},
              {value: 30}, {value: 32}, {value: 34}, {value: 36}, {value: 38}, {value: 40}]
   },
   { type: ChemTestType.pH, label: t("CHEM.PH.TEST"), units: t("CHEM.PH.UNIT"),
-    steps: [{label: t("CHEM.COLLECT.SAMPLE")}, {label: t("CHEM.ADD.TABLET")}, {label: t("CHEM.MATCH.COLOR")}],
-    values: [{value: 4, rating: ChemTestRatingType.poor}, {value: 5, rating: ChemTestRatingType.poor},
-             {value: 6, rating: ChemTestRatingType.good}, {value: 7, rating: ChemTestRatingType.excellent},
-             {value: 8, rating: ChemTestRatingType.good}, {value: 9, rating: ChemTestRatingType.poor},
-             {value: 10, rating: ChemTestRatingType.poor}]
+    steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.animation, label: t("CHEM.ADD.TABLET")},
+            {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR")}],
+    values: [{value: 4, rating: ChemTestRatingType.poor, color: "#e16f4e"}, {value: 5, rating: ChemTestRatingType.poor, color: "#f0895b"},
+             {value: 6, rating: ChemTestRatingType.good, color: "#f6c842"}, {value: 7, rating: ChemTestRatingType.excellent, color: "#cad04c"},
+             {value: 8, rating: ChemTestRatingType.good, color: "#9fc051"}, {value: 9, rating: ChemTestRatingType.poor, color: "#767a76"},
+             {value: 10, rating: ChemTestRatingType.poor, color: "#713357"}]
   },
   { type: ChemTestType.nitrate, label: t("CHEM.NITRATE.TEST"), units: t("CHEM.AIR.UNIT"),
-    steps: [{label: t("CHEM.COLLECT.SAMPLE")}, {label: t("CHEM.ADD.TABLET")}, {label: t("CHEM.MATCH.COLOR")}],
-    values: [{value: 0, rating: ChemTestRatingType.excellent}, {value: 5, rating: ChemTestRatingType.fair},
-             {value: 20, rating: ChemTestRatingType.poor}, {value: 40, rating: ChemTestRatingType.poor}]
+    steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.animation, label: t("CHEM.ADD.TABLET")},
+            {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR")}],
+    values: [{value: 0, rating: ChemTestRatingType.excellent, color: "#f7fdfd"}, {value: 5, rating: ChemTestRatingType.fair, color: "#e5bd94"},
+             {value: 20, rating: ChemTestRatingType.poor, color: "#dc8c74"}, {value: 40, rating: ChemTestRatingType.poor, color: "#d24116"}]
   },
   { type: ChemTestType.turbidity, label: t("CHEM.TURBIDITY.TEST"), units: t("CHEM.TURBIDITY.UNIT"),
-    steps: [{label: t("CHEM.COLLECT.SAMPLE")}, {label: t("CHEM.MATCH.VALUE")}],
-    values: [{value: 0, rating: ChemTestRatingType.excellent}, {value: 40, rating: ChemTestRatingType.good},
-             {value: 100, rating: ChemTestRatingType.fair}]
+    steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.resultSlider, label: t("CHEM.MATCH.VALUE")}],
+    values: [{value: 0, rating: ChemTestRatingType.excellent, icon: Turbidity0}, {value: 40, rating: ChemTestRatingType.good, icon: Turbidity40},
+             {value: 100, rating: ChemTestRatingType.fair, icon: Turbidity100}]
   },
   { type: ChemTestType.dissolvedOxygen, label: t("CHEM.OXYGEN.TEST"), units: t("CHEM.AIR.UNIT"),
-    steps: [{label: t("CHEM.COLLECT.SAMPLE")}, {label: t("CHEM.ADD.TABLETS")}, {label: t("CHEM.MATCH.COLOR")}],
-    values: [{value: 0, rating: ChemTestRatingType.poor}, {value: 4, rating: ChemTestRatingType.fair},
-             {value: 8, rating: ChemTestRatingType.excellent}]
+    steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.animation, label: t("CHEM.ADD.TABLETS")},
+            {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR")}],
+    values: [{value: 0, rating: ChemTestRatingType.poor, color: "#f7fdfd"}, {value: 4, rating: ChemTestRatingType.fair, color: "#db9363"},
+             {value: 8, rating: ChemTestRatingType.excellent, color: "#d65c2c"}]
   },
 ];
 

--- a/src/utils/chem-utils.ts
+++ b/src/utils/chem-utils.ts
@@ -54,26 +54,26 @@ export interface ChemistryTest {
   type: ChemTestType,
   label: string,
   steps: ChemTestStep[],
-  values: ChemTestValue[],
+  results: ChemTestValue[],
   units: string,
 }
 
 export const chemistryTests: ChemistryTest[] = [
   { type: ChemTestType.airTemperature, label: t("CHEM.AIRTEMP.TEST"), units: t("CHEM.TEMP.UNIT"),
     steps: [{type: StepType.tempDisplay, label: t("CHEM.READ.THERMOMETER")}],
-    values: [{value: 14}, {value: 16}, {value: 18}, {value: 20}, {value: 22}, {value: 24}, {value: 26}, {value: 28},
+    results: [{value: 14}, {value: 16}, {value: 18}, {value: 20}, {value: 22}, {value: 24}, {value: 26}, {value: 28},
              {value: 30}, {value: 32}, {value: 34}, {value: 36}, {value: 38}, {value: 40}],
   },
   { type: ChemTestType.waterTemperature, label: t("CHEM.WATERTEMP.TEST"), units: t("CHEM.TEMP.UNIT"),
     steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")},
             {type: StepType.tempDisplay, label: t("CHEM.READ.THERMOMETER")}],
-    values: [{value: 14}, {value: 16}, {value: 18}, {value: 20}, {value: 22}, {value: 24}, {value: 26}, {value: 28},
+            results: [{value: 14}, {value: 16}, {value: 18}, {value: 20}, {value: 22}, {value: 24}, {value: 26}, {value: 28},
              {value: 30}, {value: 32}, {value: 34}, {value: 36}, {value: 38}, {value: 40}]
   },
   { type: ChemTestType.pH, label: t("CHEM.PH.TEST"), units: t("CHEM.PH.UNIT"),
     steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.animation, label: t("CHEM.ADD.TABLET")},
             {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR")}],
-    values: [{value: 4, rating: ChemTestRatingType.poor, color: "#e16f4e"}, {value: 5, rating: ChemTestRatingType.poor, color: "#f0895b"},
+    results: [{value: 4, rating: ChemTestRatingType.poor, color: "#e16f4e"}, {value: 5, rating: ChemTestRatingType.poor, color: "#f0895b"},
              {value: 6, rating: ChemTestRatingType.good, color: "#f6c842"}, {value: 7, rating: ChemTestRatingType.excellent, color: "#cad04c"},
              {value: 8, rating: ChemTestRatingType.good, color: "#9fc051"}, {value: 9, rating: ChemTestRatingType.poor, color: "#767a76"},
              {value: 10, rating: ChemTestRatingType.poor, color: "#713357"}]
@@ -81,18 +81,18 @@ export const chemistryTests: ChemistryTest[] = [
   { type: ChemTestType.nitrate, label: t("CHEM.NITRATE.TEST"), units: t("CHEM.AIR.UNIT"),
     steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.animation, label: t("CHEM.ADD.TABLET")},
             {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR")}],
-    values: [{value: 0, rating: ChemTestRatingType.excellent, color: "#f7fdfd"}, {value: 5, rating: ChemTestRatingType.fair, color: "#e5bd94"},
+    results: [{value: 0, rating: ChemTestRatingType.excellent, color: "#f7fdfd"}, {value: 5, rating: ChemTestRatingType.fair, color: "#e5bd94"},
              {value: 20, rating: ChemTestRatingType.poor, color: "#dc8c74"}, {value: 40, rating: ChemTestRatingType.poor, color: "#d24116"}]
   },
   { type: ChemTestType.turbidity, label: t("CHEM.TURBIDITY.TEST"), units: t("CHEM.TURBIDITY.UNIT"),
     steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.resultSlider, label: t("CHEM.MATCH.VALUE")}],
-    values: [{value: 0, rating: ChemTestRatingType.excellent, icon: Turbidity0}, {value: 40, rating: ChemTestRatingType.good, icon: Turbidity40},
+    results: [{value: 0, rating: ChemTestRatingType.excellent, icon: Turbidity0}, {value: 40, rating: ChemTestRatingType.good, icon: Turbidity40},
              {value: 100, rating: ChemTestRatingType.fair, icon: Turbidity100}]
   },
   { type: ChemTestType.dissolvedOxygen, label: t("CHEM.OXYGEN.TEST"), units: t("CHEM.AIR.UNIT"),
     steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.animation, label: t("CHEM.ADD.TABLETS")},
             {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR")}],
-    values: [{value: 0, rating: ChemTestRatingType.poor, color: "#f7fdfd"}, {value: 4, rating: ChemTestRatingType.fair, color: "#db9363"},
+    results: [{value: 0, rating: ChemTestRatingType.poor, color: "#f7fdfd"}, {value: 4, rating: ChemTestRatingType.fair, color: "#db9363"},
              {value: 8, rating: ChemTestRatingType.excellent, color: "#d65c2c"}]
   },
 ];

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -120,7 +120,8 @@
   "ANIMAL.STONEFLY": "Stoneflies",
 
   "CHEM.TEST": "Test",
-  "CHEM.RESULT": "Water Quality Result",
+  "CHEM.RESULT": "Result",
+  "CHEM.WATER.RESULT": "Water Quality Result",
   "CHEM.TEST.INCOMPLETE": "Test not yet complete",
   "CHEM.TEST.UNSTARTED": "Test not yet run",
   "CHEM.EXCELLENT": "Excellent",

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -135,7 +135,7 @@
   "CHEM.OXYGEN.TEST": "Dissolved Oxygen",
   "CHEM.TEMP.UNIT": "°C",
   "CHEM.PH.UNIT": "pH",
-  "CHEM.AIR.UNIT": "PPM",
+  "CHEM.AIR.UNIT": "ppm",
   "CHEM.TURBIDITY.UNIT": "JTU",
   "CHEM.COLLECT.SAMPLE": "Collect sample",
   "CHEM.READ.THERMOMETER": "Read thermometer",

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -120,7 +120,8 @@
   "ANIMAL.STONEFLY": "Stoneflies",
 
   "CHEM.TEST": "Prueba",
-  "CHEM.RESULT": "Resultado de la calidad del agua",
+  "CHEM.RESULT": "Resultado",
+  "CHEM.WATER.RESULT": "Resultado de la calidad del agua",
   "CHEM.TEST.INCOMPLETE": "Prueba no completada",
   "CHEM.TEST.UNSTARTED": "Prueba aún no ejecutada",
   "CHEM.EXCELLENT": "Excelente",

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -135,7 +135,7 @@
   "CHEM.OXYGEN.TEST": "Oxígeno disuelto",
   "CHEM.TEMP.UNIT": "°C",
   "CHEM.PH.UNIT": "pH",
-  "CHEM.AIR.UNIT": "PPM",
+  "CHEM.AIR.UNIT": "ppm",
   "CHEM.TURBIDITY.UNIT": "JTU",
   "CHEM.COLLECT.SAMPLE": "Recoger muestra",
   "CHEM.READ.THERMOMETER": "Leer termómetro",


### PR DESCRIPTION
Adds sliders and results for the pH, nitrate, turbidity, and dissolved oxygen tests in the Chem Lab portion of the notebook.  Changes include:

- add ChemTestSlider and InputResult components to display slider and the resultant slider value
- update test results output state when slider is moved
- add icons for use with turbidity slider

Can be tested here:
https://leaf-pack.concord.org/branch/chem-sliders/

![sliders](https://user-images.githubusercontent.com/5126913/108470085-440a5a00-723e-11eb-886e-f96e1ee2d1cc.gif)