### PR TITLE
Minor refactor of `<App>` component

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -12,9 +12,10 @@ import { Thumbnail } from "./thumbnail/thumbnail";
 import { Notebook } from "./notebook/notebook";
 import { Tray } from "./simulation/tray";
 import { ModalDialog } from "./modal-dialog";
+import { IModelConfig, IModelInputState, IModelOutputState, IModelTransientState } from "../leaf-model-types";
 import { Model } from "../model";
 import { LeafEatersAmountType, EnvironmentType, getSunnyDayLogLabel, AlgaeEatersAmountType,
-         LeafDecompositionType, FishAmountType, LeafPackStates, TrayObject, AnimalInstance, Animals, kTraySpawnPadding,
+         LeafDecompositionType, FishAmountType, LeafPackStates, TrayObject, Animals, kTraySpawnPadding,
          kMinTrayX, kMaxTrayX, kMinTrayY, kMaxTrayY, kMinLeaves, kMaxLeaves, TrayType, Leaves, draggableAnimalTypes,
          containerIdForEnvironmentMap, environmentForContainerId
        } from "../utils/sim-utils";
@@ -25,27 +26,6 @@ import { calculateRotatedBoundingBox, calculateBoundedPosition, getRandomInteger
 import t from "../utils/translation/translate";
 
 import "./app.scss";
-
-export interface IModelConfig {}
-export interface IModelInputState {
-  environment: EnvironmentType;
-  sunnyDayFequency: number;
-}
-export interface IModelOutputState {
-  leafDecomposition: LeafDecompositionType;
-  leafEaters: LeafEatersAmountType;
-  algaeEaters: AlgaeEatersAmountType;
-  fish: FishAmountType;
-  animalInstances: AnimalInstance[];
-  showTray: boolean;
-  trayObjects: TrayObject[];
-  pti?: number;
-  habitatFeatures: Set<HabitatFeatureType>;
-  chemistryTestResults: ChemistryTestResult[];
-}
-export interface IModelTransientState {
-  time: number;
-}
 
 const kTargetStepsPerSecond = 60;
 const targetFramePeriod = 1000 / kTargetStepsPerSecond;

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -4,7 +4,6 @@ import { TouchBackend } from "react-dnd-touch-backend";
 import Modal from "react-modal";
 import { IThumbnailChooserProps, ThumbnailChooser } from "../components/thumbnail/thumbnail-chooser/thumbnail-chooser";
 import { IAppProps } from "./render-app";
-import { useModelState, IModelCurrentState, hasOwnProperties, ContainerId } from "../hooks/use-model-state";
 import { MainViewWrapper } from "./simulation/main-view-wrapper";
 import { SimulationView } from "./simulation/simulation-view";
 import { ControlPanel } from "./control-panel/control-panel";
@@ -12,10 +11,10 @@ import { Thumbnail } from "./thumbnail/thumbnail";
 import { Notebook } from "./notebook/notebook";
 import { Tray } from "./simulation/tray";
 import { ModalDialog } from "./modal-dialog";
-import { IModelConfig, IModelInputState, IModelOutputState, IModelTransientState } from "../leaf-model-types";
+import { ContainerId, useLeafModelState } from "../hooks/use-leaf-model-state";
+import { IModelConfig, IModelInputState, IModelOutputState } from "../leaf-model-types";
 import { Model } from "../model";
-import { LeafEatersAmountType, EnvironmentType, getSunnyDayLogLabel, AlgaeEatersAmountType,
-         LeafDecompositionType, FishAmountType, LeafPackStates, TrayObject, Animals, kTraySpawnPadding,
+import { EnvironmentType, getSunnyDayLogLabel, LeafPackStates, TrayObject, Animals, kTraySpawnPadding,
          kMinTrayX, kMaxTrayX, kMinTrayY, kMaxTrayY, kMinLeaves, kMaxLeaves, TrayType, Leaves, draggableAnimalTypes,
          containerIdForEnvironmentMap, environmentForContainerId
        } from "../utils/sim-utils";
@@ -36,43 +35,9 @@ const kSelectedContainerBgColor = "#f5f5f5";
 Modal.setAppElement("#app");
 
 // TODO: some of these app props are likely not needed
-export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModelConfig>> = ({onStateChange, addExternalSetStateListener, removeExternalSetStateListener, logEvent}) => {
-  const isValidExternalState = (newState: IModelCurrentState<IModelInputState, IModelOutputState>) => {
-    return hasOwnProperties(newState.inputState, ["environment", "sunnyDayFequency"]) &&
-           hasOwnProperties(newState.outputState, ["leafDecomposition", "leafEaters", "algaeEaters", "fish", "animalInstances"]);
-  };
-  const modelState = useModelState<IModelInputState, IModelOutputState, IModelTransientState>({
-    initialInputState: { environment: EnvironmentType.environment1,
-                         sunnyDayFequency: 0 },
-    initialOutputState: { leafDecomposition: LeafDecompositionType.little,
-                          leafEaters: LeafEatersAmountType.few,
-                          algaeEaters: AlgaeEatersAmountType.few,
-                          fish: FishAmountType.few,
-                          animalInstances: [],
-                          showTray: false,
-                          trayObjects: [],
-                          chemistryTestResults: [
-                            {type: ChemTestType.airTemperature, stepsComplete: 0, value: 0},
-                            {type: ChemTestType.waterTemperature, stepsComplete: 0, value: 0},
-                            {type: ChemTestType.pH, stepsComplete: 0, value: 0},
-                            {type: ChemTestType.nitrate, stepsComplete: 0, value: 0},
-                            {type: ChemTestType.turbidity, stepsComplete: 0, value: 0},
-                            {type: ChemTestType.dissolvedOxygen, stepsComplete: 0, value: 0}
-                          ],
-                          habitatFeatures: new Set()
-                        },
-    initialTransientState: {
-      time: 0
-    },
-    finalTransientState: {
-      time: 1
-    },
-    onStateChange,
-    addExternalSetStateListener,
-    removeExternalSetStateListener,
-    isValidExternalState,
-    logEvent
-  });
+export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModelConfig>> = (appProps) => {
+  const { logEvent } = appProps;
+  const modelState = useLeafModelState(appProps);
   const {inputState, setInputState,
     outputState, setOutputState,
     simulationState, pauseSimulation, rewindSimulation,

--- a/src/components/thumbnail/thumbnail.test.tsx
+++ b/src/components/thumbnail/thumbnail.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { Thumbnail } from "./thumbnail";
 import { IContainer } from "../../hooks/use-model-state";
-import { IModelInputState, IModelOutputState } from "../app";
+import { IModelInputState, IModelOutputState } from "../../leaf-model-types";
 import { AlgaeEatersAmountType, EnvironmentType, FishAmountType, LeafDecompositionType, LeafEatersAmountType } from "../../utils/sim-utils";
 
 describe("Thumbnail component", () => {

--- a/src/components/thumbnail/thumbnail.tsx
+++ b/src/components/thumbnail/thumbnail.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { IThumbnailProps } from "./thumbnail-chooser/thumbnail-chooser";
-import { IModelInputState, IModelOutputState } from "../app";
 import IconChemistryNotebook from "../../assets/chemistry-icon.svg";
 import IconHabitatNotebook from "../../assets/habitat-icon.svg";
 import IconMacroinvertebratesNotebook from "../../assets/macro-icon.svg";
 import IconPTI from "../../assets/pti-icon.svg";
 import IconSun from "../../assets/sunny-icon.svg";
+import { IModelInputState, IModelOutputState } from "../../leaf-model-types";
 import t from "../../utils/translation/translate";
 
 import "./thumbnail.scss";

--- a/src/hooks/use-leaf-model-state.ts
+++ b/src/hooks/use-leaf-model-state.ts
@@ -1,0 +1,46 @@
+import { IAppProps } from "../components/render-app";
+import { IModelConfig, IModelInputState, IModelOutputState, IModelTransientState } from "../leaf-model-types";
+import { ChemTestType } from "../utils/chem-utils";
+import { AlgaeEatersAmountType, EnvironmentType, FishAmountType, LeafDecompositionType, LeafEatersAmountType } from "../utils/sim-utils";
+import useModelState, { ContainerId, hasOwnProperties, IModelCurrentState } from "./use-model-state";
+
+export { ContainerId };
+
+const isValidExternalState = (newState: IModelCurrentState<IModelInputState, IModelOutputState>) => {
+  return hasOwnProperties(newState.inputState, ["environment", "sunnyDayFequency"]) &&
+          hasOwnProperties(newState.outputState, ["leafDecomposition", "leafEaters", "algaeEaters", "fish", "animalInstances"]);
+};
+
+interface IProps extends IAppProps<IModelInputState, IModelOutputState, IModelConfig> {
+}
+export const useLeafModelState = (props: IProps) => {
+  return useModelState<IModelInputState, IModelOutputState, IModelTransientState>({
+    initialInputState: { environment: EnvironmentType.environment1,
+                         sunnyDayFequency: 0 },
+    initialOutputState: { leafDecomposition: LeafDecompositionType.little,
+                          leafEaters: LeafEatersAmountType.few,
+                          algaeEaters: AlgaeEatersAmountType.few,
+                          fish: FishAmountType.few,
+                          animalInstances: [],
+                          showTray: false,
+                          trayObjects: [],
+                          chemistryTestResults: [
+                            {type: ChemTestType.airTemperature, stepsComplete: 0, value: 0},
+                            {type: ChemTestType.waterTemperature, stepsComplete: 0, value: 0},
+                            {type: ChemTestType.pH, stepsComplete: 0, value: 0},
+                            {type: ChemTestType.nitrate, stepsComplete: 0, value: 0},
+                            {type: ChemTestType.turbidity, stepsComplete: 0, value: 0},
+                            {type: ChemTestType.dissolvedOxygen, stepsComplete: 0, value: 0}
+                          ],
+                          habitatFeatures: new Set()
+                        },
+    initialTransientState: {
+      time: 0
+    },
+    finalTransientState: {
+      time: 1
+    },
+    isValidExternalState,
+    ...props
+  });
+};

--- a/src/leaf-model-types.ts
+++ b/src/leaf-model-types.ts
@@ -1,0 +1,27 @@
+import { ChemistryTestResult } from "./utils/chem-utils";
+import { HabitatFeatureType } from "./utils/habitat-utils";
+import {
+  AlgaeEatersAmountType, AnimalInstance, EnvironmentType, FishAmountType,
+  LeafDecompositionType, LeafEatersAmountType, TrayObject
+} from "./utils/sim-utils";
+
+export interface IModelConfig {}
+export interface IModelInputState {
+  environment: EnvironmentType;
+  sunnyDayFequency: number;
+}
+export interface IModelOutputState {
+  leafDecomposition: LeafDecompositionType;
+  leafEaters: LeafEatersAmountType;
+  algaeEaters: AlgaeEatersAmountType;
+  fish: FishAmountType;
+  animalInstances: AnimalInstance[];
+  showTray: boolean;
+  trayObjects: TrayObject[];
+  pti?: number;
+  habitatFeatures: Set<HabitatFeatureType>;
+  chemistryTestResults: ChemistryTestResult[];
+}
+export interface IModelTransientState {
+  time: number;
+}

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -1,5 +1,5 @@
+import { IModelInputState } from "./leaf-model-types";
 import { Model, kMaxSteps } from "./model";
-import { IModelInputState } from "./components/app";
 import { EnvironmentType } from "./utils/sim-utils";
 
 describe("model", () => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { IModelInputState } from "./components/app";
+import { IModelInputState } from "./leaf-model-types";
 import { EnvironmentType, LeafDecompositionType, LeafEatersAmountType, AlgaeEatersAmountType, FishAmountType, Animal, Animals,
          AnimalInstance, LeafDecompositionFinalValues, LeafEatersFinalValues, AlgaeEatersFinalValues, FishFinalValues,
        } from "./utils/sim-utils";


### PR DESCRIPTION
- Move leaf model state types into `leaf-model-types.ts`
- Add `useLeafModelState` hook

Simplify `<App>` component by breaking off some small pieces.