### PR TITLE
Chemistry test module refactor

### DIFF
--- a/src/chem-tests/air-temperature.ts
+++ b/src/chem-tests/air-temperature.ts
@@ -1,0 +1,37 @@
+import { ChemistryTest, ChemTestType, StepType } from "../utils/chem-types";
+import t from "../utils/translation/translate";
+
+import AirTemp0 from "../assets/chemistry/air-temperature/air-temp-0.svg";
+import AirTemp1A from "../assets/chemistry/air-temperature/air-temp-1a.svg";
+import AirTemp1B from "../assets/chemistry/air-temperature/air-temp-1b.svg";
+import AirTemp1C from "../assets/chemistry/air-temperature/air-temp-1c.svg";
+import AirTemp1D from "../assets/chemistry/air-temperature/air-temp-1d.svg";
+import AirTemp1E from "../assets/chemistry/air-temperature/air-temp-1e.svg";
+import AirTemp1F from "../assets/chemistry/air-temperature/air-temp-1f.svg";
+import AirTemp1G_22 from "../assets/chemistry/air-temperature/air-temp-1g-22.svg";
+import AirTemp1G_30 from "../assets/chemistry/air-temperature/air-temp-1g-30.svg";
+import AirTemp1G_38 from "../assets/chemistry/air-temperature/air-temp-1g-38.svg";
+
+export const airTemperatureTest: ChemistryTest = {
+  type: ChemTestType.airTemperature, label: t("CHEM.AIRTEMP.TEST"), units: t("CHEM.TEMP.UNIT"),
+  InitialImage: AirTemp0,
+  steps: [
+    {type: StepType.tempDisplay, label: t("CHEM.READ.THERMOMETER"), Image: "1g",
+      frames: [
+        {label: "0", image: AirTemp0, duration: 0.25},
+        {label: "1a", image: AirTemp1A, duration: 1},
+        {label: "1b", image: AirTemp1B, duration: 2},
+        {label: "1c", image: AirTemp1C, duration: 2},
+        {label: "1d", image: AirTemp1D, duration: 2},
+        {label: "1e", image: AirTemp1E, duration: 2},
+        {label: "1f", image: AirTemp1F, duration: 2},
+        {label: "1g", image: "byValue", duration: -1},
+      ]},
+  ],
+  results: [
+    {value: 14}, {value: 16}, {value: 18}, {value: 20},
+    {value: 22, frames: {"1g": AirTemp1G_22}}, {value: 24}, {value: 26}, {value: 28},
+    {value: 30, frames: {"1g": AirTemp1G_30}}, {value: 32}, {value: 34}, {value: 36},
+    {value: 38, frames: {"1g": AirTemp1G_38}}, {value: 40}
+  ],
+};

--- a/src/chem-tests/turbidity.ts
+++ b/src/chem-tests/turbidity.ts
@@ -1,0 +1,55 @@
+import { ChemistryTest, ChemTestRatingType, ChemTestType, StepType } from "../utils/chem-types";
+import t from "../utils/translation/translate";
+
+import Turbidity0 from "../assets/chemistry/turbidity/turbidity-0.svg";
+import Turbidity1A from "../assets/chemistry/turbidity/turbidity-1a.svg";
+import Turbidity1B from "../assets/chemistry/turbidity/turbidity-1b.svg";
+import Turbidity1C from "../assets/chemistry/turbidity/turbidity-1c.svg";
+import Turbidity1D from "../assets/chemistry/turbidity/turbidity-1d.svg";
+import Turbidity1E_0 from "../assets/chemistry/turbidity/turbidity-1e-0.svg";
+import Turbidity1E_40 from "../assets/chemistry/turbidity/turbidity-1e-40.svg";
+import Turbidity1E_100 from "../assets/chemistry/turbidity/turbidity-1e-100.svg";
+import Turbidity1F_0 from "../assets/chemistry/turbidity/turbidity-1f-0.svg";
+import Turbidity1F_40 from "../assets/chemistry/turbidity/turbidity-1f-40.svg";
+import Turbidity1F_100 from "../assets/chemistry/turbidity/turbidity-1f-100.svg";
+import Turbidity2A_0 from "../assets/chemistry/turbidity/turbidity-2a-0.svg";
+import Turbidity2A_40 from "../assets/chemistry/turbidity/turbidity-2a-40.svg";
+import Turbidity2A_100 from "../assets/chemistry/turbidity/turbidity-2a-100.svg";
+import Turbidity2B_0 from "../assets/chemistry/turbidity/turbidity-2b-0.svg";
+import Turbidity2B_40 from "../assets/chemistry/turbidity/turbidity-2b-40.svg";
+import Turbidity2B_100 from "../assets/chemistry/turbidity/turbidity-2b-100.svg";
+import Turbidity0Disk from "../assets/disk-0.svg";
+import Turbidity40Disk from "../assets/disk-40.svg";
+import Turbidity100Disk from "../assets/disk-100.svg";
+
+export const turbidityTest: ChemistryTest = {
+  type: ChemTestType.turbidity, label: t("CHEM.TURBIDITY.TEST"), units: t("CHEM.TURBIDITY.UNIT"),
+  InitialImage: Turbidity0,
+  steps: [
+    {type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE"), Image: "1f",
+      frames: [
+        {label: "0", image: Turbidity0, duration: 0.25},
+        {label: "1a", image: Turbidity1A, duration: 1},
+        {label: "1b", image: Turbidity1B, duration: 2},
+        {label: "1c", image: Turbidity1C, duration: 0},
+        {label: "1d", image: Turbidity1D, duration: 2},
+        {label: "1d-", image: "none", duration: 0},
+        {label: "1e", image: "byValue", duration: 1},
+        {label: "1f", image: "byValue", duration: -1},
+      ]},
+    {type: StepType.resultSlider, label: t("CHEM.MATCH.VALUE"), Image: "2b",
+      frames: [
+        {label: "1f", image: "byValue", duration: 0.25},
+        {label: "2a", image: "byValue", duration: 0},
+        {label: "2b", image: "byValue", duration: -1}
+      ]}
+  ],
+  results: [
+    {value: 0, rating: ChemTestRatingType.excellent, Icon: Turbidity0Disk,
+      frames: { "1e": Turbidity1E_0, "1f": Turbidity1F_0, "2a": Turbidity2A_0, "2b": Turbidity2B_0}},
+    {value: 40, rating: ChemTestRatingType.good, Icon: Turbidity40Disk,
+      frames: { "1e": Turbidity1E_40, "1f": Turbidity1F_40, "2a": Turbidity2A_40, "2b": Turbidity2B_40}},
+    {value: 100, rating: ChemTestRatingType.fair, Icon: Turbidity100Disk,
+      frames: { "1e": Turbidity1E_100, "1f": Turbidity1F_100, "2a": Turbidity2A_100, "2b": Turbidity2B_100}}
+  ]
+};

--- a/src/chem-tests/water-temperature.ts
+++ b/src/chem-tests/water-temperature.ts
@@ -1,0 +1,48 @@
+import { ChemistryTest, ChemTestType, StepType } from "../utils/chem-types";
+import t from "../utils/translation/translate";
+
+import WaterTemp0 from "../assets/chemistry/water-temperature/water-temp-0.svg";
+import WaterTemp1A from "../assets/chemistry/water-temperature/water-temp-1a.svg";
+import WaterTemp1B from "../assets/chemistry/water-temperature/water-temp-1b.svg";
+import WaterTemp1C from "../assets/chemistry/water-temperature/water-temp-1c.svg";
+import WaterTemp2A from "../assets/chemistry/water-temperature/water-temp-2a.svg";
+import WaterTemp2B from "../assets/chemistry/water-temperature/water-temp-2b.svg";
+import WaterTemp2C from "../assets/chemistry/water-temperature/water-temp-2c.svg";
+import WaterTemp2D from "../assets/chemistry/water-temperature/water-temp-2d.svg";
+import WaterTemp2E from "../assets/chemistry/water-temperature/water-temp-2e.svg";
+import WaterTemp2F from "../assets/chemistry/water-temperature/water-temp-2f.svg";
+import WaterTemp2G_12 from "../assets/chemistry/water-temperature/water-temp-2g-12.svg";
+import WaterTemp2G_22 from "../assets/chemistry/water-temperature/water-temp-2g-22.svg";
+import WaterTemp2G_24 from "../assets/chemistry/water-temperature/water-temp-2g-24.svg";
+
+export const waterTemperatureTest: ChemistryTest = {
+  type: ChemTestType.waterTemperature, label: t("CHEM.WATERTEMP.TEST"), units: t("CHEM.TEMP.UNIT"),
+  InitialImage: WaterTemp0,
+  steps: [
+    {type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE"), Image: WaterTemp1C,
+      frames: [
+        {label: "0", image: WaterTemp0, duration: 0.25},
+        {label: "1a", image: WaterTemp1A, duration: 1},
+        {label: "1b", image: WaterTemp1B, duration: 1.5},
+        {label: "1c", image: WaterTemp1C, duration: -1},
+      ]},
+    {type: StepType.tempDisplay, label: t("CHEM.READ.THERMOMETER"), Image: "2g",
+      frames: [
+        {label: "1c", image: WaterTemp1C, duration: 0.25},
+        {label: "2a", image: WaterTemp2A, duration: 0},
+        {label: "2b", image: WaterTemp2B, duration: 2},
+        {label: "2c", image: WaterTemp2C, duration: 0},
+        {label: "2d", image: WaterTemp2D, duration: 1.5},
+        {label: "2e", image: WaterTemp2E, duration: 2},
+        {label: "2e-", image: "none", duration: 0},
+        {label: "2f", image: WaterTemp2F, duration: 1},
+        {label: "2g", image: "byValue", duration: -1}
+      ]}
+  ],
+  results: [
+    {value: 10}, {value: 12, frames: {"2g": WaterTemp2G_12}}, {value: 14}, {value: 16},
+    {value: 18}, {value: 20}, {value: 22, frames: {"2g": WaterTemp2G_22}},
+    {value: 24, frames: {"2g": WaterTemp2G_24}}, {value: 26}, {value: 28}, {value: 30},
+    {value: 32}, {value: 34}, {value: 36}, {value: 38}, {value: 40}
+  ]
+};

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -14,13 +14,14 @@ import { ModalDialog } from "./modal-dialog";
 import { ContainerId, useLeafModelState } from "../hooks/use-leaf-model-state";
 import { IModelConfig, IModelInputState, IModelOutputState } from "../leaf-model-types";
 import { Model } from "../model";
+import { ChemistryTestResult, ChemTestType } from "../utils/chem-types";
+import { chemistryTests } from "../utils/chem-utils";
 import { containerIdForEnvironmentMap, environmentForContainerId, EnvironmentType } from "../utils/environment";
 import { getSunnyDayLogLabel, LeafPackStates, TrayObject, Animals, kTraySpawnPadding,
          kMinTrayX, kMaxTrayX, kMinTrayY, kMaxTrayY, kMinLeaves, kMaxLeaves, TrayType, Leaves, draggableAnimalTypes
        } from "../utils/sim-utils";
 import { HabitatFeatureType } from "../utils/habitat-utils";
 import { getPTIScore } from "../utils/macro-utils";
-import { ChemistryTestResult, ChemTestType, chemistryTests } from "../utils/chem-utils";
 import { calculateRotatedBoundingBox, calculateBoundedPosition, getRandomInteger, shuffleArray } from "../utils/math-utils";
 import t from "../utils/translation/translate";
 

--- a/src/components/notebook/chem-results.tsx
+++ b/src/components/notebook/chem-results.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { ChemistryTestResult, chemistryTests, chemTestRatings } from "../../utils/chem-utils";
+import { ChemistryTestResult } from "../../utils/chem-types";
+import { chemistryTests, chemTestRatings } from "../../utils/chem-utils";
 import CheckIcon from "../../assets/check-icon.svg";
 import t from "../../utils/translation/translate";
 

--- a/src/components/notebook/chem-test-slider.tsx
+++ b/src/components/notebook/chem-test-slider.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Slider from "@material-ui/core/Slider";
-import { ChemTestValue } from "../../utils/chem-utils";
 import IconHorizontalHandle from "../../assets/icon-slider-horizontal.svg";
+import { ChemTestValue } from "../../utils/chem-types";
 
 import "./chem-test-slider.scss";
 import "../../components/control-panel/slider.scss";

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
-  ChemistryTest, ChemistryTestResult, ChemistryValues, ChemTestStep, ChemTestType, StepType
-} from "../../utils/chem-utils";
+  ChemistryTest, ChemTestType, ChemTestStep, StepType, ChemistryTestResult, ChemistryValues
+} from "../../utils/chem-types";
 import { ChemTestSlider } from "./chem-test-slider";
 import { InputResult } from "./input-result";
 import CheckIcon from "../../assets/check-icon.svg";

--- a/src/components/notebook/chemistry-panel.tsx
+++ b/src/components/notebook/chemistry-panel.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { chemistryTests, ChemTestType, ChemistryTestResult, ChemistryValues } from "../../utils/chem-utils";
+import { ChemistryTestResult, ChemistryValues, ChemTestType } from "../../utils/chem-types";
+import { chemistryTests } from "../../utils/chem-utils";
 import { SectionButtons } from "./section-buttons";
 import { ChemResults } from "./chem-results";
 import { ChemTest } from "./chem-test";

--- a/src/components/notebook/input-result.tsx
+++ b/src/components/notebook/input-result.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { ChemistryTest, ChemistryTestResult, chemTestRatings } from "../../utils/chem-utils";
+import { ChemistryTest, ChemistryTestResult } from "../../utils/chem-types";
+import { chemTestRatings } from "../../utils/chem-utils";
 import t from "../../utils/translation/translate";
 
 import "./input-result.scss";

--- a/src/components/notebook/notebook.tsx
+++ b/src/components/notebook/notebook.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import t from "../../utils/translation/translate";
+import { ChemistryTestResult, ChemistryValues, ChemTestType } from "../../utils/chem-types";
 import { EnvironmentType } from "../../utils/environment";
 import { TrayObject, TrayType } from "../../utils/sim-utils";
 import { HabitatFeatureType } from "../../utils/habitat-utils";
-import { ChemTestType, ChemistryTestResult, ChemistryValues } from "../../utils/chem-utils";
 import { HabitatPanel } from "./habitat-panel";
 import { ChemistryPanel } from "./chemistry-panel";
 import { MacroPanel } from "./macro-panel";

--- a/src/hooks/use-leaf-model-state.ts
+++ b/src/hooks/use-leaf-model-state.ts
@@ -1,6 +1,6 @@
 import { IAppProps } from "../components/render-app";
 import { IModelConfig, IModelInputState, IModelOutputState, IModelTransientState } from "../leaf-model-types";
-import { ChemTestType } from "../utils/chem-utils";
+import { ChemTestType } from "../utils/chem-types";
 import { EnvironmentType } from "../utils/environment";
 import { AlgaeEatersAmountType, FishAmountType, LeafDecompositionType, LeafEatersAmountType } from "../utils/sim-utils";
 import useModelState, { ContainerId, hasOwnProperties, IModelCurrentState } from "./use-model-state";

--- a/src/leaf-model-types.ts
+++ b/src/leaf-model-types.ts
@@ -1,4 +1,4 @@
-import { ChemistryTestResult, ChemistryValues } from "./utils/chem-utils";
+import { ChemistryTestResult, ChemistryValues } from "./utils/chem-types";
 import { EnvironmentType } from "./utils/environment";
 import { HabitatFeatureType } from "./utils/habitat-utils";
 import {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,5 @@
 import { IModelInputState } from "./leaf-model-types";
-import { ChemistryFinalValues } from "./utils/chem-utils";
+import { chemistryFinalValues } from "./utils/chem-utils";
 import { EnvironmentType } from "./utils/environment";
 import { LeafDecompositionType, LeafEatersAmountType, AlgaeEatersAmountType, FishAmountType, Animal, Animals,
          AnimalInstance, LeafDecompositionFinalValues, LeafEatersFinalValues, AlgaeEatersFinalValues, FishFinalValues,
@@ -115,7 +115,7 @@ export class Model {
       algaeEaters,
       fish,
       animalInstances: this.animalInstances,
-      chemistryValues: ChemistryFinalValues[this.environment]
+      chemistryValues: chemistryFinalValues[this.environment]
     };
   }
 }

--- a/src/utils/chem-types.ts
+++ b/src/utils/chem-types.ts
@@ -1,0 +1,68 @@
+import { SVGProps } from "react";
+
+export enum ChemTestType {
+  airTemperature = "airTemperature",
+  waterTemperature = "waterTemperature",
+  pH = "pH",
+  nitrate = "nitrate",
+  turbidity = "turbidity",
+  dissolvedOxygen= "dissolvedOxygen",
+}
+
+export enum ChemTestRatingType {
+  excellent = "excellent",
+  good = "good",
+  fair = "fair",
+  poor = "poor",
+}
+
+export interface ChemTestRating {
+  type: ChemTestRatingType;
+  label: string;
+  color: string;
+}
+
+export enum StepType {
+  animation = "animation",
+  resultSlider = "resultSlider",
+  tempDisplay = "tempDisplay",
+}
+
+export interface ChemTestAnimationFrame {
+  label: string;
+  image: "none" | "byValue" | React.FC<SVGProps<SVGSVGElement>>;
+  duration: number;
+}
+
+export interface ChemTestStep {
+  type: StepType;
+  label: string;
+  frames?: ChemTestAnimationFrame[];
+  // string => animation frame reference
+  Image?: string | React.FC<SVGProps<SVGSVGElement>>;  // in lieu of animation
+}
+
+export interface ChemTestValue {
+  value: number;
+  rating?: ChemTestRatingType;
+  color?: string;
+  Icon?: React.FC<SVGProps<SVGSVGElement>>;
+  frames?: Record<string, React.FC<SVGProps<SVGSVGElement>>>;
+}
+
+export interface ChemistryTest {
+  type: ChemTestType;
+  label: string;
+  InitialImage?: React.FC<SVGProps<SVGSVGElement>>;
+  steps: ChemTestStep[];
+  results: ChemTestValue[];
+  units: string;
+}
+
+export type ChemistryValues = Record<ChemTestType, number>;
+
+export interface ChemistryTestResult {
+  type: ChemTestType;
+  stepsComplete: number;
+  value: number;
+}

--- a/src/utils/chem-utils.ts
+++ b/src/utils/chem-utils.ts
@@ -1,72 +1,13 @@
-import { SVGProps } from "react";
+import {
+  ChemistryTest, ChemistryValues, ChemTestRating, ChemTestRatingType, ChemTestType, StepType
+} from "./chem-types";
 import { EnvironmentType } from "./environment";
 import t from "./translation/translate";
 
-import AirTemp0 from "../assets/chemistry/air-temperature/air-temp-0.svg";
-import AirTemp1A from "../assets/chemistry/air-temperature/air-temp-1a.svg";
-import AirTemp1B from "../assets/chemistry/air-temperature/air-temp-1b.svg";
-import AirTemp1C from "../assets/chemistry/air-temperature/air-temp-1c.svg";
-import AirTemp1D from "../assets/chemistry/air-temperature/air-temp-1d.svg";
-import AirTemp1E from "../assets/chemistry/air-temperature/air-temp-1e.svg";
-import AirTemp1F from "../assets/chemistry/air-temperature/air-temp-1f.svg";
-import AirTemp1G_22 from "../assets/chemistry/air-temperature/air-temp-1g-22.svg";
-import AirTemp1G_30 from "../assets/chemistry/air-temperature/air-temp-1g-30.svg";
-import AirTemp1G_38 from "../assets/chemistry/air-temperature/air-temp-1g-38.svg";
-import Turbidity0 from "../assets/chemistry/turbidity/turbidity-0.svg";
-import Turbidity1A from "../assets/chemistry/turbidity/turbidity-1a.svg";
-import Turbidity1B from "../assets/chemistry/turbidity/turbidity-1b.svg";
-import Turbidity1C from "../assets/chemistry/turbidity/turbidity-1c.svg";
-import Turbidity1D from "../assets/chemistry/turbidity/turbidity-1d.svg";
-import Turbidity1E_0 from "../assets/chemistry/turbidity/turbidity-1e-0.svg";
-import Turbidity1E_40 from "../assets/chemistry/turbidity/turbidity-1e-40.svg";
-import Turbidity1E_100 from "../assets/chemistry/turbidity/turbidity-1e-100.svg";
-import Turbidity1F_0 from "../assets/chemistry/turbidity/turbidity-1f-0.svg";
-import Turbidity1F_40 from "../assets/chemistry/turbidity/turbidity-1f-40.svg";
-import Turbidity1F_100 from "../assets/chemistry/turbidity/turbidity-1f-100.svg";
-import Turbidity2A_0 from "../assets/chemistry/turbidity/turbidity-2a-0.svg";
-import Turbidity2A_40 from "../assets/chemistry/turbidity/turbidity-2a-40.svg";
-import Turbidity2A_100 from "../assets/chemistry/turbidity/turbidity-2a-100.svg";
-import Turbidity2B_0 from "../assets/chemistry/turbidity/turbidity-2b-0.svg";
-import Turbidity2B_40 from "../assets/chemistry/turbidity/turbidity-2b-40.svg";
-import Turbidity2B_100 from "../assets/chemistry/turbidity/turbidity-2b-100.svg";
-import Turbidity0Disk from "../assets/disk-0.svg";
-import Turbidity40Disk from "../assets/disk-40.svg";
-import Turbidity100Disk from "../assets/disk-100.svg";
-import WaterTemp0 from "../assets/chemistry/water-temperature/water-temp-0.svg";
-import WaterTemp1A from "../assets/chemistry/water-temperature/water-temp-1a.svg";
-import WaterTemp1B from "../assets/chemistry/water-temperature/water-temp-1b.svg";
-import WaterTemp1C from "../assets/chemistry/water-temperature/water-temp-1c.svg";
-import WaterTemp2A from "../assets/chemistry/water-temperature/water-temp-2a.svg";
-import WaterTemp2B from "../assets/chemistry/water-temperature/water-temp-2b.svg";
-import WaterTemp2C from "../assets/chemistry/water-temperature/water-temp-2c.svg";
-import WaterTemp2D from "../assets/chemistry/water-temperature/water-temp-2d.svg";
-import WaterTemp2E from "../assets/chemistry/water-temperature/water-temp-2e.svg";
-import WaterTemp2F from "../assets/chemistry/water-temperature/water-temp-2f.svg";
-import WaterTemp2G_12 from "../assets/chemistry/water-temperature/water-temp-2g-12.svg";
-import WaterTemp2G_22 from "../assets/chemistry/water-temperature/water-temp-2g-22.svg";
-import WaterTemp2G_24 from "../assets/chemistry/water-temperature/water-temp-2g-24.svg";
+import { airTemperatureTest } from "../chem-tests/air-temperature";
+import { turbidityTest } from "../chem-tests/turbidity";
+import { waterTemperatureTest } from "../chem-tests/water-temperature";
 
-export enum ChemTestType {
-  airTemperature = "airTemperature",
-  waterTemperature = "waterTemperature",
-  pH = "pH",
-  nitrate = "nitrate",
-  turbidity = "turbidity",
-  dissolvedOxygen= "dissolvedOxygen",
-}
-
-export enum ChemTestRatingType {
-  excellent = "excellent",
-  good = "good",
-  fair = "fair",
-  poor = "poor",
-}
-
-export interface ChemTestRating {
-  type: ChemTestRatingType;
-  label: string;
-  color: string;
-}
 export const chemTestRatings: ChemTestRating[] = [
   {type: ChemTestRatingType.excellent, label: t("CHEM.EXCELLENT"), color: "#a4f9be"},
   {type: ChemTestRatingType.good, label: t("CHEM.GOOD"), color: "#94e5ff"},
@@ -74,100 +15,9 @@ export const chemTestRatings: ChemTestRating[] = [
   {type: ChemTestRatingType.poor, label: t("CHEM.POOR"), color: "#ffacac"},
 ];
 
-export enum StepType {
-  animation = "animation",
-  resultSlider = "resultSlider",
-  tempDisplay = "tempDisplay",
-}
-
-export function lookupByValue(label: string, value: number, results: ChemTestValue[]) {
-  return results.find(result => result.value === value)?.frames?.[label];
-}
-
-export interface ChemTestAnimationFrame {
-  label: string;
-  image: "none" | "byValue" | React.FC<SVGProps<SVGSVGElement>>;
-  duration: number;
-}
-
-export interface ChemTestStep {
-  type: StepType;
-  label: string;
-  frames?: ChemTestAnimationFrame[];
-  // string => animation frame reference
-  Image?: string | React.FC<SVGProps<SVGSVGElement>>;  // in lieu of animation
-}
-
-export interface ChemTestValue {
-  value: number;
-  rating?: ChemTestRatingType;
-  color?: string;
-  Icon?: React.FC<SVGProps<SVGSVGElement>>;
-  frames?: Record<string, React.FC<SVGProps<SVGSVGElement>>>
-}
-
-export interface ChemistryTest {
-  type: ChemTestType,
-  label: string,
-  InitialImage?: React.FC<SVGProps<SVGSVGElement>>;
-  steps: ChemTestStep[],
-  results: ChemTestValue[],
-  units: string,
-}
-
 export const chemistryTests: ChemistryTest[] = [
-  { type: ChemTestType.airTemperature, label: t("CHEM.AIRTEMP.TEST"), units: t("CHEM.TEMP.UNIT"),
-    InitialImage: AirTemp0,
-    steps: [
-      {type: StepType.tempDisplay, label: t("CHEM.READ.THERMOMETER"), Image: "1g",
-        frames: [
-          {label: "0", image: AirTemp0, duration: 0.25},
-          {label: "1a", image: AirTemp1A, duration: 1},
-          {label: "1b", image: AirTemp1B, duration: 2},
-          {label: "1c", image: AirTemp1C, duration: 2},
-          {label: "1d", image: AirTemp1D, duration: 2},
-          {label: "1e", image: AirTemp1E, duration: 2},
-          {label: "1f", image: AirTemp1F, duration: 2},
-          {label: "1g", image: "byValue", duration: -1},
-        ]},
-    ],
-    results: [
-      {value: 14}, {value: 16}, {value: 18}, {value: 20},
-      {value: 22, frames: {"1g": AirTemp1G_22}}, {value: 24}, {value: 26}, {value: 28},
-      {value: 30, frames: {"1g": AirTemp1G_30}}, {value: 32}, {value: 34}, {value: 36},
-      {value: 38, frames: {"1g": AirTemp1G_38}}, {value: 40}
-    ],
-  },
-  { type: ChemTestType.waterTemperature, label: t("CHEM.WATERTEMP.TEST"), units: t("CHEM.TEMP.UNIT"),
-    InitialImage: WaterTemp0,
-    steps: [
-      {type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE"), Image: WaterTemp1C,
-        frames: [
-          {label: "0", image: WaterTemp0, duration: 0.25},
-          {label: "1a", image: WaterTemp1A, duration: 1},
-          {label: "1b", image: WaterTemp1B, duration: 1.5},
-          {label: "1c", image: WaterTemp1C, duration: -1},
-        ]},
-      {type: StepType.tempDisplay, label: t("CHEM.READ.THERMOMETER"), Image: "2g",
-        frames: [
-          {label: "1c", image: WaterTemp1C, duration: 0.25},
-          {label: "2a", image: WaterTemp2A, duration: 0},
-          {label: "2b", image: WaterTemp2B, duration: 2},
-          {label: "2c", image: WaterTemp2C, duration: 0},
-          {label: "2d", image: WaterTemp2D, duration: 1.5},
-          {label: "2e", image: WaterTemp2E, duration: 2},
-          {label: "2e-", image: "none", duration: 0},
-          {label: "2f", image: WaterTemp2F, duration: 1},
-          {label: "2g", image: "byValue", duration: -1}
-        ]}
-    ],
-    results: [
-      {value: 10}, {value: 12, frames: {"2g": WaterTemp2G_12}}, {value: 14}, {value: 16},
-      {value: 18}, {value: 20}, {value: 22, frames: {"2g": WaterTemp2G_22}},
-      {value: 24, frames: {"2g": WaterTemp2G_24}}, {value: 26}, {value: 28}, {value: 30},
-      {value: 32}, {value: 34}, {value: 36}, {value: 38}, {value: 40}
-    ]
-  },
+  airTemperatureTest,
+  waterTemperatureTest,
   { type: ChemTestType.pH, label: t("CHEM.PH.TEST"), units: t("CHEM.PH.UNIT"),
     steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.animation, label: t("CHEM.ADD.TABLET")},
             {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR")}],
@@ -182,36 +32,7 @@ export const chemistryTests: ChemistryTest[] = [
     results: [{value: 0, rating: ChemTestRatingType.excellent, color: "#f7fdfd"}, {value: 5, rating: ChemTestRatingType.fair, color: "#e5bd94"},
              {value: 20, rating: ChemTestRatingType.poor, color: "#dc8c74"}, {value: 40, rating: ChemTestRatingType.poor, color: "#d24116"}]
   },
-  { type: ChemTestType.turbidity, label: t("CHEM.TURBIDITY.TEST"), units: t("CHEM.TURBIDITY.UNIT"),
-    InitialImage: Turbidity0,
-    steps: [
-      {type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE"), Image: "1f",
-        frames: [
-          {label: "0", image: Turbidity0, duration: 0.25},
-          {label: "1a", image: Turbidity1A, duration: 1},
-          {label: "1b", image: Turbidity1B, duration: 2},
-          {label: "1c", image: Turbidity1C, duration: 0},
-          {label: "1d", image: Turbidity1D, duration: 2},
-          {label: "1d-", image: "none", duration: 0},
-          {label: "1e", image: "byValue", duration: 1},
-          {label: "1f", image: "byValue", duration: -1},
-        ]},
-      {type: StepType.resultSlider, label: t("CHEM.MATCH.VALUE"), Image: "2b",
-        frames: [
-          {label: "1f", image: "byValue", duration: 0.25},
-          {label: "2a", image: "byValue", duration: 0},
-          {label: "2b", image: "byValue", duration: -1}
-        ]}
-    ],
-    results: [
-      {value: 0, rating: ChemTestRatingType.excellent, Icon: Turbidity0Disk,
-        frames: { "1e": Turbidity1E_0, "1f": Turbidity1F_0, "2a": Turbidity2A_0, "2b": Turbidity2B_0}},
-      {value: 40, rating: ChemTestRatingType.good, Icon: Turbidity40Disk,
-        frames: { "1e": Turbidity1E_40, "1f": Turbidity1F_40, "2a": Turbidity2A_40, "2b": Turbidity2B_40}},
-      {value: 100, rating: ChemTestRatingType.fair, Icon: Turbidity100Disk,
-        frames: { "1e": Turbidity1E_100, "1f": Turbidity1F_100, "2a": Turbidity2A_100, "2b": Turbidity2B_100}}
-    ]
-  },
+  turbidityTest,
   { type: ChemTestType.dissolvedOxygen, label: t("CHEM.OXYGEN.TEST"), units: t("CHEM.AIR.UNIT"),
     steps: [{type: StepType.animation, label: t("CHEM.COLLECT.SAMPLE")}, {type: StepType.animation, label: t("CHEM.ADD.TABLETS")},
             {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR")}],
@@ -220,8 +41,7 @@ export const chemistryTests: ChemistryTest[] = [
   },
 ];
 
-export type ChemistryValues = Record<ChemTestType, number>;
-export const ChemistryFinalValues: Record<EnvironmentType, ChemistryValues> = {
+export const chemistryFinalValues: Record<EnvironmentType, ChemistryValues> = {
   [EnvironmentType.environment1]: {
     [ChemTestType.airTemperature]: 22,
     [ChemTestType.waterTemperature]: 12,
@@ -255,9 +75,3 @@ export const ChemistryFinalValues: Record<EnvironmentType, ChemistryValues> = {
     [ChemTestType.dissolvedOxygen]: 4
   }
 };
-
-export interface ChemistryTestResult {
-  type: ChemTestType,
-  stepsComplete: number,
-  value: number
-}


### PR DESCRIPTION
I was tempted to do this as part of the last PR, but the changes there were already sufficiently extensive that I thought it made sense to hold off on the refactor.

- moves individual chemistry test specification into their own modules under `chem-tests`
- separates chemistry-related types into a separate `chem-types.ts` module