### PR TITLE
Replace modal alert error with transient "X" feedback [#177011400]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3027,6 +3027,32 @@
         }
       }
     },
+    "@testing-library/user-event": {
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.7.2.tgz",
+      "integrity": "sha512-6uUYor7b0+JAcanK0rmCEZGo6t0n2F4WUKXL9toQg495a9YE2MHlJ8GWzfCgsUPyVHw8SNaMN8UrZoHABf+oOg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.18",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+          "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@svgr/webpack": "^5.5.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react-hooks": "^3.7.0",
+    "@testing-library/user-event": "^12.7.2",
     "@types/enzyme": "^3.10.8",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^26.0.19",

--- a/src/assets/macroinvertebrates/incorrect-sensitive.svg
+++ b/src/assets/macroinvertebrates/incorrect-sensitive.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 42 42">
+    <g fill="none" fill-rule="evenodd" opacity=".75">
+        <g fill="#00AEEF" fill-rule="nonzero">
+            <path d="M577.872 1717L562.999 1731.871 548.128 1717 542 1723.128 556.871 1737.999 542 1752.872 548.129 1759 562.999 1744.127 577.872 1759 584 1752.872 569.127 1737.999 584 1723.129z" transform="translate(-542 -1717)"/>
+        </g>
+    </g>
+</svg>

--- a/src/assets/macroinvertebrates/incorrect-somewhat-sensitive.svg
+++ b/src/assets/macroinvertebrates/incorrect-somewhat-sensitive.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 42 42">
+    <g fill="none" fill-rule="evenodd" opacity=".75">
+        <g fill="#2A2B86" fill-rule="nonzero">
+            <path d="M629.872 1717L614.999 1731.871 600.128 1717 594 1723.128 608.871 1737.999 594 1752.872 600.129 1759 614.999 1744.127 629.872 1759 636 1752.872 621.127 1737.999 636 1723.129z" transform="translate(-594 -1717)"/>
+        </g>
+    </g>
+</svg>

--- a/src/assets/macroinvertebrates/incorrect-tolerant.svg
+++ b/src/assets/macroinvertebrates/incorrect-tolerant.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 42 42">
+    <g fill="none" fill-rule="evenodd" opacity=".75">
+        <g fill="#F58221" fill-rule="nonzero">
+            <path d="M681.872 1717L666.999 1731.871 652.128 1717 646 1723.128 660.871 1737.999 646 1752.872 652.129 1759 666.999 1744.127 681.872 1759 688 1752.872 673.127 1737.999 688 1723.129z" transform="translate(-646 -1717)"/>
+        </g>
+    </g>
+</svg>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { TouchBackend } from "react-dnd-touch-backend";
-import Modal from "react-modal";
+// import Modal from "react-modal";
 import { IThumbnailChooserProps, ThumbnailChooser } from "../components/thumbnail/thumbnail-chooser/thumbnail-chooser";
 import { IAppProps } from "./render-app";
 import { MainViewWrapper } from "./simulation/main-view-wrapper";
@@ -10,7 +10,7 @@ import { ControlPanel } from "./control-panel/control-panel";
 import { Thumbnail } from "./thumbnail/thumbnail";
 import { Notebook } from "./notebook/notebook";
 import { Tray } from "./simulation/tray";
-import { ModalDialog } from "./modal-dialog";
+// import { ModalDialog } from "./modal-dialog";
 import { ContainerId, useLeafModelState } from "../hooks/use-leaf-model-state";
 import { IModelConfig, IModelInputState, IModelOutputState } from "../leaf-model-types";
 import { Model } from "../model";
@@ -33,7 +33,7 @@ let lastStepTime: number;
 const kSavedBgColor = "#000000";
 const kSelectedContainerBgColor = "#f5f5f5";
 
-Modal.setAppElement("#app");
+// Modal.setAppElement("#app");
 
 // TODO: some of these app props are likely not needed
 export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModelConfig>> = (appProps) => {
@@ -211,8 +211,6 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
         }
       });
       setOutputStateAndSave({ trayObjects: updatedTrayObjects });
-    } else {
-      setShowModal(true);
     }
     setTraySelectionType(undefined);
   };
@@ -263,7 +261,7 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
     setOutputStateAndSave({ chemistryTestResults: updatedChemistryTestResults });
   };
 
-  const [showModal, setShowModal] = useState(false);
+  // const [showModal, setShowModal] = useState(false);
 
   return (
     <div className="app" data-testid="app">
@@ -328,12 +326,12 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
           onChangeEnvironment={handleChangeEnvironment}
         />
       </div>
-      <ModalDialog
+      {/* <ModalDialog
         title={t("MACRO.ERROR.TITLE")}
         label={t("MACRO.ERROR.DESCRIPTION")}
         onClose={() => setShowModal(false)}
         showModal={showModal}
-      />
+      /> */}
     </div>
   );
 };

--- a/src/components/notebook/macro-animal-row.test.tsx
+++ b/src/components/notebook/macro-animal-row.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MacroAnimalRow } from "./macro-animal-row";
+import { AnimalType, getAnimal, SensitivityType } from "../../utils/sim-utils";
+
+jest.mock("react-dnd", () => ({
+  useDrop: () => [{ isOver: false }, () => null]
+}));
+
+describe("MacroAnimalRow component", () => {
+  const animal = getAnimal(AnimalType.caddisFly)!;
+  const collectedTrayAnimal: any = { type: AnimalType.caddisFly, collected: true };
+  const correctTrayAnimal: any = { type: AnimalType.caddisFly, collected: false };
+  const incorrectTrayAnimal: any = { type: AnimalType.aquaticWorm, collected: false };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders with no tray animal", () => {
+    render(<MacroAnimalRow animal={animal} count={0} onCategorizeAnimal={() => null} />);
+    expect(screen.getByTestId("critter-caddisFly")).toBeInTheDocument();
+  });
+
+  it("renders with collected tray animal", () => {
+    render(<MacroAnimalRow animal={animal} trayAnimal={collectedTrayAnimal}
+                            count={0} onCategorizeAnimal={() => null} />);
+    expect(screen.getByTestId("critter-caddisFly")).toBeInTheDocument();
+  });
+
+  it("categorizes correct animal on click", () => {
+    render(<MacroAnimalRow animal={animal} traySelectionType={AnimalType.caddisFly}
+                            trayAnimal={correctTrayAnimal}
+                            count={0} onCategorizeAnimal={() => null} />);
+    userEvent.click(screen.getByTestId("empty-box-caddisFly"));
+  });
+
+  it("provides error feedback for sensitive species on click", () => {
+    const sensitivity: any = { type: SensitivityType.sensitive };
+    render(<MacroAnimalRow animal={animal} traySelectionType={AnimalType.blackFly}
+                            trayAnimal={incorrectTrayAnimal} sensitivity={sensitivity}
+                            count={0} onCategorizeAnimal={() => null} />);
+    userEvent.click(screen.getByTestId("empty-box-caddisFly"));
+    expect(screen.getByTestId("error-sensitive")).toBeInTheDocument();
+  });
+
+  it("provides error feedback for somewhat sensitive species on click", () => {
+    const sensitivity: any = { type: SensitivityType.somewhatSensitive };
+    render(<MacroAnimalRow animal={animal} traySelectionType={AnimalType.blackFly}
+                            trayAnimal={incorrectTrayAnimal} sensitivity={sensitivity}
+                            count={0} onCategorizeAnimal={() => null} />);
+    userEvent.click(screen.getByTestId("empty-box-caddisFly"));
+    expect(screen.getByTestId("error-somewhat-sensitive")).toBeInTheDocument();
+  });
+
+  it("provides error feedback for tolerant species on click", () => {
+    const sensitivity: any = { type: SensitivityType.tolerant };
+    render(<MacroAnimalRow animal={animal} traySelectionType={AnimalType.blackFly}
+                            trayAnimal={incorrectTrayAnimal} sensitivity={sensitivity}
+                            count={0} onCategorizeAnimal={() => null} />);
+    userEvent.click(screen.getByTestId("empty-box-caddisFly"));
+    expect(screen.getByTestId("error-tolerant")).toBeInTheDocument();
+  });
+});

--- a/src/components/notebook/macro-animal-row.tsx
+++ b/src/components/notebook/macro-animal-row.tsx
@@ -63,7 +63,7 @@ export const MacroAnimalRow: React.FC<IProps> = (props) => {
 
   return (
     <div key={`critter-${animal.type}`} className="critter" style={{backgroundColor: sensitivity?.backgroundColor}} ref={drop}
-          data-testid={`critter-${animal.type}`} onTransitionEnd={() => setErrorClass("")}>
+          data-testid={`critter-${animal.type}`}>
       { trayAnimal?.collected
         ? <div className="image-box" style={{borderColor: sensitivity?.graphColor}}>
             <AnimalIcon className="animal-icon" />

--- a/src/components/notebook/macro-animal-row.tsx
+++ b/src/components/notebook/macro-animal-row.tsx
@@ -1,6 +1,12 @@
 import React from "react";
-import { Sensitivity, TrayObject, TrayType, Animal, draggableAnimalTypes } from "../../utils/sim-utils";
 import { useDrop } from "react-dnd";
+import IncorrectSensitive from "../../assets/macroinvertebrates/incorrect-sensitive.svg";
+import IncorrectSomewhatSensitive from "../../assets/macroinvertebrates/incorrect-somewhat-sensitive.svg";
+import IncorrectTolerant from "../../assets/macroinvertebrates/incorrect-tolerant.svg";
+import { useErrorClass } from "../../hooks/use-error-class";
+import {
+  Animal, draggableAnimalTypes, Sensitivity, SensitivityType, TrayObject, TrayType
+} from "../../utils/sim-utils";
 
 import "./macro-panel.scss";
 
@@ -8,24 +14,47 @@ import "./macro-panel.scss";
 const kMaxCritters = 60;
 const kMaxGraphWidth = 64;
 
+const errorX = (sensitivity: SensitivityType, errorClass: string) => {
+  switch (sensitivity) {
+    case SensitivityType.sensitive:
+      return <IncorrectSensitive className={errorClass} data-testid="error-sensitive"/>;
+    case SensitivityType.somewhatSensitive:
+      return <IncorrectSomewhatSensitive className={errorClass} data-testid="error-somewhat-sensitive"/>;
+    case SensitivityType.tolerant:
+      return <IncorrectTolerant className={errorClass} data-testid="error-tolerant"/>;
+  }
+};
+
 interface IProps {
-  trayAnimal: TrayObject | undefined;
+  trayAnimal?: TrayObject;
   animal: Animal;
-  AnimalIcon: any;
-  index: number;
-  sensitivity: Sensitivity | undefined;
+  sensitivity?: Sensitivity;
   count: number;
   onCategorizeAnimal: (trayType: TrayType | undefined, notebookType: TrayType | undefined) => void;
   traySelectionType?: TrayType;
 }
 
 export const MacroAnimalRow: React.FC<IProps> = (props) => {
-  const { trayAnimal, animal, AnimalIcon, index, sensitivity, count, onCategorizeAnimal, traySelectionType } = props;
+  const { trayAnimal, animal, sensitivity, count, onCategorizeAnimal, traySelectionType } = props;
+  const { image: AnimalIcon } = animal;
+  const [errorClass, setErrorClass] = useErrorClass();
+
+  const handleCategorizeAnimal = (trayType: TrayType | undefined, notebookType: TrayType | undefined) => {
+    if (trayType && notebookType) {
+      if (trayType === notebookType) {
+        setErrorClass("");
+        onCategorizeAnimal(trayType, notebookType);
+      }
+      else {
+        setErrorClass("error");
+      }
+    }
+  };
 
   const [{ isOver }, drop] = useDrop({
     accept: draggableAnimalTypes,
     drop: (item: any) => {
-      onCategorizeAnimal(item.type, trayAnimal?.type);
+      handleCategorizeAnimal(item?.type, trayAnimal?.type);
     },
     collect: monitor => ({
       isOver: !!monitor.isOver(),
@@ -33,17 +62,22 @@ export const MacroAnimalRow: React.FC<IProps> = (props) => {
   });
 
   return (
-    <div key={`critter-${index}`} className="critter" style={{backgroundColor: sensitivity?.backgroundColor}} ref={drop}>
+    <div key={`critter-${animal.type}`} className="critter" style={{backgroundColor: sensitivity?.backgroundColor}} ref={drop}
+          data-testid={`critter-${animal.type}`} onTransitionEnd={() => setErrorClass("")}>
       { trayAnimal?.collected
         ? <div className="image-box" style={{borderColor: sensitivity?.graphColor}}>
             <AnimalIcon className="animal-icon" />
           </div>
-        : <div
-            className={`empty-box ${traySelectionType ? "enabled" : ""} ${isOver ? "highlight" : ""}`}
-            style={{backgroundColor: isOver ? sensitivity?.backgroundColor : sensitivity?.blockColor,
-                    borderColor: isOver ? sensitivity?.graphColor : "#333333"}}
-            onClick={() => onCategorizeAnimal(traySelectionType, trayAnimal?.type)}
-          />
+        : <>
+            <div
+              className={`empty-box ${traySelectionType ? "enabled" : ""} ${isOver ? "highlight" : ""}`}
+              data-testid={`empty-box-${animal.type}`}
+              style={{backgroundColor: isOver ? sensitivity?.backgroundColor : sensitivity?.blockColor,
+                      borderColor: isOver ? sensitivity?.graphColor : "#333333"}}
+              onClick={() => handleCategorizeAnimal(traySelectionType, trayAnimal?.type)}
+            />
+            {errorClass && sensitivity && errorX(sensitivity.type, errorClass)}
+          </>
       }
       <div className="name">{animal.label}</div>
       <div className="count">{count}</div>

--- a/src/components/notebook/macro-panel.scss
+++ b/src/components/notebook/macro-panel.scss
@@ -18,6 +18,7 @@
     height: 252px;
 
     .critter {
+      position: relative;
       display: flex;
       flex-direction: row;
       align-items: center;
@@ -68,6 +69,17 @@
         &.enabled {
           pointer-events: auto;
           cursor: pointer;
+        }
+      }
+
+      .error {
+        position: absolute;
+        left: 12px;
+        opacity: 0.75;
+        transition: opacity 0.5s linear;
+
+        &.fading {
+          opacity: 0;
         }
       }
 

--- a/src/components/notebook/macro-panel.tsx
+++ b/src/components/notebook/macro-panel.tsx
@@ -29,7 +29,6 @@ export const MacroPanel: React.FC<IProps> = (props) => {
           const sensitivity = Sensitivities.find((s) => s.type === animal.sensitivity);
           const trayAnimal = trayObjects.find((obj) => obj.type === animal.type);
           const count = trayAnimal?.collected ? trayAnimal.count : 0;
-          const AnimalIcon = animal.image;
           return (
             index >= kCrittersPerSection * currentSection &&
             index < kCrittersPerSection * currentSection + kCrittersPerSection &&
@@ -37,8 +36,6 @@ export const MacroPanel: React.FC<IProps> = (props) => {
               key={`row-${index}`}
               trayAnimal={trayAnimal}
               animal={animal}
-              AnimalIcon={AnimalIcon}
-              index={index}
               count={count}
               sensitivity={sensitivity}
               onCategorizeAnimal={onCategorizeAnimal}

--- a/src/hooks/use-error-class.test.ts
+++ b/src/hooks/use-error-class.test.ts
@@ -11,7 +11,7 @@ describe("useErrorClass", () => {
     jest.useRealTimers();
   });
 
-  test("works as expected", () => {
+  test("works with default values", () => {
     const { result } = renderHook<string, readonly [string, (s: string) => void]>(() => useErrorClass());
     expect(result.current[0]).toBe("");
 
@@ -21,12 +21,32 @@ describe("useErrorClass", () => {
     expect(result.current[0]).toBe("error");
 
     act(() => {
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
     });
     expect(result.current[0]).toBe("error fading");
 
     act(() => {
-      result.current[1]("");
+      jest.runAllTimers();
+    });
+    expect(result.current[0]).toBe("");
+  });
+
+  test("works with specific values", () => {
+    const { result } = renderHook<string, readonly [string, (s: string) => void]>(() => useErrorClass(1000, 1000));
+    expect(result.current[0]).toBe("");
+
+    act(() => {
+      result.current[1]("error");
+    });
+    expect(result.current[0]).toBe("error");
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(result.current[0]).toBe("error fading");
+
+    act(() => {
+      jest.runAllTimers();
     });
     expect(result.current[0]).toBe("");
   });

--- a/src/hooks/use-error-class.test.ts
+++ b/src/hooks/use-error-class.test.ts
@@ -1,0 +1,43 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { useErrorClass } from "./use-error-class";
+
+describe("useErrorClass", () => {
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("works as expected", () => {
+    const { result } = renderHook<string, readonly [string, (s: string) => void]>(() => useErrorClass());
+    expect(result.current[0]).toBe("");
+
+    act(() => {
+      result.current[1]("error");
+    });
+    expect(result.current[0]).toBe("error");
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(result.current[0]).toBe("error fading");
+
+    act(() => {
+      result.current[1]("");
+    });
+    expect(result.current[0]).toBe("");
+  });
+
+  test("cancels timer on unmount", () => {
+    const { result, unmount } = renderHook<string, readonly [string, (s: string) => void]>(() => useErrorClass());
+    act(() => {
+      result.current[1]("error");
+    });
+    expect(result.current[0]).toBe("error");
+
+    unmount();
+  });
+});

--- a/src/hooks/use-error-class.ts
+++ b/src/hooks/use-error-class.ts
@@ -2,19 +2,25 @@ import { useEffect, useRef, useState } from "react";
 
 export type ErrorClass = "" | "error" | "error fading";
 
-export const useErrorClass = () => {
+export const useErrorClass = (showTime = 3000, fadeTime = 500) => {
   const [errorClass, setErrorClass] = useState<ErrorClass>("");
   const errorTimer = useRef<number | null>(null);
   const clearTimer = () => errorTimer.current ? clearTimeout(errorTimer.current) : undefined;
 
   const _setErrorClass = (error: ErrorClass) => {
     clearTimer();
+    // show the error
     setErrorClass(error);
     if (error === "error") {
       errorTimer.current = window.setTimeout(() => {
+        // fade the error
         setErrorClass("error fading");
-        errorTimer.current = null;
-      }, 3000);
+        errorTimer.current = window.setTimeout(() => {
+          // remove the error
+          setErrorClass("");
+          errorTimer.current = null;
+        }, fadeTime);
+      }, showTime);
     }
   };
 

--- a/src/hooks/use-error-class.ts
+++ b/src/hooks/use-error-class.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from "react";
+
+export type ErrorClass = "" | "error" | "error fading";
+
+export const useErrorClass = () => {
+  const [errorClass, setErrorClass] = useState<ErrorClass>("");
+  const errorTimer = useRef<number | null>(null);
+  const clearTimer = () => errorTimer.current ? clearTimeout(errorTimer.current) : undefined;
+
+  const _setErrorClass = (error: ErrorClass) => {
+    clearTimer();
+    setErrorClass(error);
+    if (error === "error") {
+      errorTimer.current = window.setTimeout(() => {
+        setErrorClass("error fading");
+        errorTimer.current = null;
+      }, 3000);
+    }
+  };
+
+  useEffect(() => {
+    return clearTimer;
+  }, []);
+
+  return [errorClass, _setErrorClass] as const;
+};

--- a/src/utils/sim-utils.ts
+++ b/src/utils/sim-utils.ts
@@ -382,6 +382,10 @@ export const Animals: Animal[] = [
   }
 ];
 
+export function getAnimal(type: AnimalType) {
+  return Animals.find(animal => animal.type === type);
+}
+
 export interface AnimalInstance {
   type: AnimalType;
   spawnTime: number;


### PR DESCRIPTION
Testable at https://leaf-pack.concord.org/branch/no-modal-error/.

@mklewandowski I made one improvement that occurred to me in the shower this morning. The previous implementation required the client to clear the error in its `onTransitionEnd()` callback. This is error-prone (caller might forget) and also potentially conflicts with other client behaviors (what if the client has other transitions that aren't related to the error?). Therefore, I moved the clearing of the error into the hook and eliminated the need for the `onTransitionEnd()` callback. The only downside is that now the removal of the error may not precisely correspond to the end of the transition, but I don't think anyone will notice or care if the error class is removed a few milliseconds before/after the actual end of the fade. You may want to take a quick look at the additional commit.