### PR TITLE
Chemistry test animation improvements [#177050949]

### DIFF
--- a/src/chem-tests/air-temperature.ts
+++ b/src/chem-tests/air-temperature.ts
@@ -25,7 +25,7 @@ export const airTemperatureTest: ChemistryTest = {
         {label: "1d", image: AirTemp1D, duration: 2},
         {label: "1e", image: AirTemp1E, duration: 2},
         {label: "1f", image: AirTemp1F, duration: 2},
-        {label: "1g", image: "byValue", duration: -1},
+        {label: "1g", image: "byValue", duration: 1.5},
       ]},
   ],
   results: [

--- a/src/chem-tests/dissolved-oxygen.ts
+++ b/src/chem-tests/dissolved-oxygen.ts
@@ -42,7 +42,7 @@ export const dissolvedOxygen: ChemistryTest = {
       frames: [
         {label: "0", image: do_0, duration: 0.25},
         {label: "1a", image: do_1A, duration: 0},
-        {label: "1b", image: do_1B, duration: -1}
+        {label: "1b", image: do_1B, duration: 1}
       ]},
     {type: StepType.animation, label: t("CHEM.ADD.TABLETS"),
       frames: [
@@ -68,14 +68,14 @@ export const dissolvedOxygen: ChemistryTest = {
         {label: "2q", image: "byValue", duration: 0},
         {label: "2r", image: "byValue", duration: 0},
         {label: "2s", image: "byValue", duration: 0},
-        {label: "2t", image: "byValue", duration: -1},
+        {label: "2t", image: "byValue", duration: 1},
       ]},
     {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR"),
       frames: [
         {label: "2t", image: "byValue", duration: 0.25},
         {label: "2t-", image: "none", duration: 0},
         {label: "3a", image: "byValue", duration: 1},
-        {label: "3b", image: "byValue", duration: -1}
+        {label: "3b", image: "byValue", duration: 0}
       ]},
   ],
     results: [

--- a/src/chem-tests/nitrate.ts
+++ b/src/chem-tests/nitrate.ts
@@ -46,7 +46,7 @@ export const nitrateTest: ChemistryTest = {
       frames: [
         {label: "0", image: nitrate_0, duration: 0.25},
         {label: "1a", image: nitrate_1A, duration: 0},
-        {label: "1b", image: nitrate_1B, duration: -1}
+        {label: "1b", image: nitrate_1B, duration: 1}
       ]},
     {type: StepType.animation, label: t("CHEM.ADD.TABLET"),
       frames: [
@@ -76,7 +76,7 @@ export const nitrateTest: ChemistryTest = {
         {label: "2u", image: nitrate_2U, duration: 0},
         {label: "2v", image: nitrate_2V, duration: 0},
         {label: "2w", image: nitrate_2W, duration: 0},
-        {label: "2x", image: nitrate_2X, duration: -1},
+        {label: "2x", image: nitrate_2X, duration: 1},
       ]},
     {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR"),
       frames: [
@@ -84,7 +84,7 @@ export const nitrateTest: ChemistryTest = {
         {label: "2x-", image: "none", duration: 0},
         {label: "3a", image: "byValue", duration: 1},
         {label: "3b", image: "byValue", duration: 0},
-        {label: "3c", image: "byValue", duration: -1}
+        {label: "3c", image: "byValue", duration: 0}
       ]},
   ],
   results: [

--- a/src/chem-tests/ph.ts
+++ b/src/chem-tests/ph.ts
@@ -47,7 +47,7 @@ export const phTest: ChemistryTest = {
       frames: [
         {label: "0", image: pH_0, duration: 0.25},
         {label: "1a", image: pH_1A, duration: 0},
-        {label: "1b", image: pH_1B, duration: -1}
+        {label: "1b", image: pH_1B, duration: 1}
       ]},
     {type: StepType.animation, label: t("CHEM.ADD.TABLET"),
       frames: [
@@ -63,14 +63,14 @@ export const phTest: ChemistryTest = {
         {label: "2h", image: "byValue", duration: 0},
         {label: "2i", image: "byValue", duration: 0},
         {label: "2j", image: "byValue", duration: 0},
-        {label: "2k", image: "byValue", duration: -1},
+        {label: "2k", image: "byValue", duration: 1},
       ]},
     {type: StepType.resultSlider, label: t("CHEM.MATCH.COLOR"),
       frames: [
         {label: "2k", image: "byValue", duration: 0.25},
         {label: "2k-", image: "none", duration: 0},
         {label: "3a", image: "byValue", duration: 0},
-        {label: "3b", image: "byValue", duration: -1}
+        {label: "3b", image: "byValue", duration: 0}
       ]},
   ],
   results: [

--- a/src/chem-tests/turbidity.ts
+++ b/src/chem-tests/turbidity.ts
@@ -35,13 +35,13 @@ export const turbidityTest: ChemistryTest = {
         {label: "1d", image: Turbidity1D, duration: 2},
         {label: "1d-", image: "none", duration: 0},
         {label: "1e", image: "byValue", duration: 1},
-        {label: "1f", image: "byValue", duration: -1},
+        {label: "1f", image: "byValue", duration: 1.5},
       ]},
     {type: StepType.resultSlider, label: t("CHEM.MATCH.VALUE"),
       frames: [
         {label: "1f", image: "byValue", duration: 0.25},
         {label: "2a", image: "byValue", duration: 0},
-        {label: "2b", image: "byValue", duration: -1}
+        {label: "2b", image: "byValue", duration: 0}
       ]}
   ],
   results: [

--- a/src/chem-tests/water-temperature.ts
+++ b/src/chem-tests/water-temperature.ts
@@ -24,7 +24,7 @@ export const waterTemperatureTest: ChemistryTest = {
         {label: "0", image: WaterTemp0, duration: 0.25},
         {label: "1a", image: WaterTemp1A, duration: 1},
         {label: "1b", image: WaterTemp1B, duration: 1.5},
-        {label: "1c", image: WaterTemp1C, duration: -1},
+        {label: "1c", image: WaterTemp1C, duration: 1.5},
       ]},
     {type: StepType.tempDisplay, label: t("CHEM.READ.THERMOMETER"),
       frames: [
@@ -36,7 +36,7 @@ export const waterTemperatureTest: ChemistryTest = {
         {label: "2e", image: WaterTemp2E, duration: 2},
         {label: "2e-", image: "none", duration: 0},
         {label: "2f", image: WaterTemp2F, duration: 1},
-        {label: "2g", image: "byValue", duration: -1}
+        {label: "2g", image: "byValue", duration: 1.5}
       ]}
   ],
   results: [

--- a/src/components/notebook/chem-test-animation.test.tsx
+++ b/src/components/notebook/chem-test-animation.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { ChemTestAnimation } from "./chem-test-animation";
 import { ChemTestAnimationFrame } from "../../utils/chem-types";
 
@@ -16,22 +16,73 @@ describe("ChemTestAnimation component", () => {
     jest.useRealTimers();
   });
 
-  const singleFrame: ChemTestAnimationFrame[] = [
+  const TestImage: React.FC = () => {
+    return null;
+  };
+
+  const singleBlankFrame: ChemTestAnimationFrame[] = [
           {label: "0", image: "none", duration: 0 }
         ];
+
+  const singleFrame: ChemTestAnimationFrame[] = [
+          {label: "0", image: TestImage, duration: 0 }
+        ];
+
+  const singleFrameByValue: ChemTestAnimationFrame[] = [
+          {label: "0", image: "byValue", duration: 0 }
+        ];
+  const finalValueEntry: any = { frames: { "0": TestImage } };
 
   const twoFrames: ChemTestAnimationFrame[] = [
           {label: "0", image: "none", duration: 10 },
           {label: "1", image: "none", duration: 10 }
         ];
 
-  it("renders single frame", async () => {
-    render(<ChemTestAnimation frames={singleFrame} timeout={10} onComplete={onComplete} />);
-    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1), { timeout: 100 });
+  it("handles empty frames array", () => {
+    render(<ChemTestAnimation frames={[]} isComplete={false} onComplete={onComplete} />);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders single frame with default timeout", () => {
+    render(<ChemTestAnimation frames={singleBlankFrame} isComplete={false} onComplete={onComplete} />);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders single frame", () => {
+    render(<ChemTestAnimation frames={singleFrame} timeout={0} isComplete={false} onComplete={onComplete} />);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders single frame by value", () => {
+    render(<ChemTestAnimation frames={singleFrameByValue} timeout={0} isComplete={false} onComplete={onComplete} />);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders single frame by value with result map", () => {
+    render(<ChemTestAnimation frames={singleFrameByValue} finalValueEntry={finalValueEntry} timeout={0} isComplete={false} onComplete={onComplete} />);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
   it("renders two frames", async () => {
-    render(<ChemTestAnimation frames={twoFrames} timeout={10} onComplete={onComplete} />);
-    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1), { timeout: 100 });
+    render(<ChemTestAnimation frames={twoFrames} timeout={0} isComplete={false} onComplete={onComplete} />);
+    act(() => {
+      jest.runAllTimers();
+    });
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
   });
 });

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -25,6 +25,7 @@ export const ChemTest: React.FC<IProps> = (props) => {
   const testResult = useCurrent(chemistryTestResults.find((result) => result.type === chemistryTest.type));
   const currentStep = testResult.current?.currentStep;
   const stepsComplete = testResult.current?.stepsComplete ?? 0;
+  const isComplete = (currentStep != null) && (stepsComplete > currentStep);
   const currentStepInfo = currentStep != null || stepsComplete > 0
           ? chemistryTest.steps[Math.max(0, currentStep ?? stepsComplete - 1)]
           : undefined;
@@ -85,7 +86,7 @@ export const ChemTest: React.FC<IProps> = (props) => {
             {StepImage && <StepImage/>}
             {stepFrames && !StepImage &&
               <ChemTestAnimation key={animationKey} frames={stepFrames} finalValueEntry={finalValueEntry}
-                                onComplete={handleAnimationComplete} />}
+                                isComplete={isComplete} onComplete={handleAnimationComplete} />}
             {currentStepInfo && !stepFrames && !StepImage ? `${currentStepInfo.label} image` : undefined}
           </div>
           {currentStepInfo?.type === StepType.resultSlider &&

--- a/src/hooks/use-frame-timer.test.ts
+++ b/src/hooks/use-frame-timer.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { useFrameTimer } from "./use-frame-timer";
+
+type UseFrameTimerReturn = readonly [number, (n: number) => void];
+
+describe("useErrorClass", () => {
+
+  const onComplete = jest.fn();
+
+  beforeEach(() => {
+    onComplete.mockReset();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("handles 0 frames", async () => {
+    const { result } = renderHook<number, UseFrameTimerReturn>(() =>
+                        useFrameTimer({ numFrames: 0 }));
+    expect(result.current[0]).toBe(-1);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(result.current[0]).toBe(0);
+    expect(onComplete).toHaveBeenCalledTimes(0);
+  });
+
+  test("handles 0 frames", async () => {
+    const { result } = renderHook<number, UseFrameTimerReturn>(() =>
+                        useFrameTimer({ numFrames: 0, initialDuration: 0.5, onComplete }));
+    expect(result.current[0]).toBe(-1);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(result.current[0]).toBe(0);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles 1 frame", async () => {
+    const { result } = renderHook<number, UseFrameTimerReturn>(() =>
+                        useFrameTimer({ numFrames: 1, onComplete }));
+    expect(result.current[0]).toBe(0);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(result.current[0]).toBe(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles 2 frames", async () => {
+    const { result } = renderHook<number, UseFrameTimerReturn>(() =>
+                        useFrameTimer({ numFrames: 2, onComplete }));
+    expect(result.current[0]).toBe(0);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(result.current[0]).toBe(1);
+    act(() => {
+      result.current[1](100);
+      jest.runAllTimers();
+    });
+    expect(result.current[0]).toBe(2);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles 2 frames with isComplete", async () => {
+    const { result } = renderHook<number, UseFrameTimerReturn>(() =>
+                        useFrameTimer({ numFrames: 2, isComplete: true, onComplete }));
+    expect(result.current[0]).toBe(1);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(result.current[0]).toBe(1);
+    expect(onComplete).toHaveBeenCalledTimes(0);
+  });
+
+  test("clears timer on unmount", async () => {
+    const { result, unmount } = renderHook<number, UseFrameTimerReturn>(() =>
+                                  useFrameTimer({ numFrames: 2, onComplete }));
+    expect(result.current[0]).toBe(0);
+    act(() => {
+      unmount();
+    });
+    expect(onComplete).toHaveBeenCalledTimes(0);
+  });
+
+});

--- a/src/hooks/use-frame-timer.ts
+++ b/src/hooks/use-frame-timer.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface IProps {
+  numFrames: number;
+  initialDuration?: number;
+  isComplete?: boolean;
+  onComplete?: () => void;
+}
+export const useFrameTimer = ({numFrames, initialDuration = 1, isComplete = false, onComplete}: IProps) => {
+  const lastFrame = numFrames - 1;
+  const [frame, setFrame] = useState(isComplete || (numFrames === 0) ? lastFrame : 0);
+
+  const timerId = useRef<number | null>(null);
+
+  const nextFrame = useCallback(() => {
+    setFrame(index => {
+      (index === lastFrame) && onComplete?.();
+      return index + 1;
+    });
+    timerId.current = null;
+  }, [lastFrame, onComplete]);
+
+  const waitForNextFrame = useCallback((duration: number) => {
+    timerId.current = window.setTimeout(nextFrame, 1000 * duration);
+  }, [nextFrame]);
+
+  useEffect(() => {
+    // set the initial timer on mount
+    if (!isComplete) {
+      waitForNextFrame(initialDuration);
+    }
+    // clear the timer when we unmount
+    return () => {
+      timerId.current && window.clearTimeout(timerId.current);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return [frame, waitForNextFrame] as const;
+};


### PR DESCRIPTION
- wait correct amount of time after end of animation
- don't rerun animations that have already been run

Testable at https://leaf-pack.concord.org/branch/fix-animation/.

@mklewandowski Fixing the bugs didn't actually take very long. After that I decided to split the animation code into a hook that handles the timer and the animation component that handles the rendering. Finally, I spent some time figuring out how to unit test both the hook and the component.