### PR TITLE
177050797 chem lab fixes

### DIFF
--- a/src/chem-tests/dissolved-oxygen.ts
+++ b/src/chem-tests/dissolved-oxygen.ts
@@ -79,7 +79,7 @@ export const dissolvedOxygen: ChemistryTest = {
       ]},
   ],
     results: [
-      {value: 0, rating: ChemTestRatingType.poor, color: "#f7fdfd"},
+      {value: 0, rating: ChemTestRatingType.poor, color: "#f7fdfd", borderColor: "#999999"},
       {value: 4, rating: ChemTestRatingType.fair, color: "#db9363",
         frames: {"2p": do_2P_4, "2q": do_2Q_4, "2r": do_2R_4, "2s": do_2S_4, "2t": do_2T_4, "3a": do_3A_4, "3b": do_3B_4}},
       {value: 8, rating: ChemTestRatingType.excellent, color: "#d65c2c",

--- a/src/chem-tests/nitrate.ts
+++ b/src/chem-tests/nitrate.ts
@@ -88,7 +88,7 @@ export const nitrateTest: ChemistryTest = {
       ]},
   ],
   results: [
-    {value: 0, rating: ChemTestRatingType.excellent, color: "#f7fdfd",
+    {value: 0, rating: ChemTestRatingType.excellent, color: "#f7fdfd", borderColor: "#999999",
       frames: {"3a": nitrate_3A_0, "3b": nitrate_3B_0, "3c": nitrate_3C_0}},
     {value: 5, rating: ChemTestRatingType.fair, color: "#e5bd94",
       frames: {"3a": nitrate_3A_5, "3b": nitrate_3B_5, "3c": nitrate_3C_5}},

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -315,7 +315,6 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
               chemistryTestResults={chemistryTestResults}
               onUpdateTestResult={handleUpdateTestResult}
               traySelectionType={traySelectionType}
-              isSimFinished={isFinished}
             />
           </div>
         </DndProvider>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -15,7 +15,7 @@ import { ContainerId, useLeafModelState } from "../hooks/use-leaf-model-state";
 import { IModelConfig, IModelInputState, IModelOutputState } from "../leaf-model-types";
 import { Model } from "../model";
 import { ChemistryTestResult, IUpdateChemistryTestResult } from "../utils/chem-types";
-import { chemistryTests } from "../utils/chem-utils";
+import { chemistryTests, chemistryFinalValues } from "../utils/chem-utils";
 import { containerIdForEnvironmentMap, environmentForContainerId, EnvironmentType } from "../utils/environment";
 import { getSunnyDayLogLabel, LeafPackStates, TrayObject, Animals, kTraySpawnPadding,
          kMinTrayX, kMaxTrayX, kMinTrayY, kMaxTrayY, kMinLeaves, kMaxLeaves, TrayType, Leaves, draggableAnimalTypes
@@ -49,7 +49,7 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
   } = modelState;
   const {environment, sunnyDayFequency} = inputState;
   const {fish, habitatFeatures, leafDecomposition, showTray, trayObjects,
-          chemistryValues, chemistryTestResults} = outputState;
+          chemistryTestResults} = outputState;
   const {time} = transientState;
   const {isRunning, isPaused, isFinished} = simulationState;
   const modelRef = useRef<Model>(new Model(inputState));
@@ -311,7 +311,7 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
               featureSelections={habitatFeatures}
               onSelectFeature={handleHabitatSelectFeature}
               onCategorizeAnimal={handleCategorizeAnimal}
-              chemistryValues={chemistryValues}
+              chemistryValues={chemistryFinalValues[environment]}
               chemistryTestResults={chemistryTestResults}
               onUpdateTestResult={handleUpdateTestResult}
               traySelectionType={traySelectionType}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -315,7 +315,7 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
               chemistryTestResults={chemistryTestResults}
               onUpdateTestResult={handleUpdateTestResult}
               traySelectionType={traySelectionType}
-              isRunning={isRunning}
+              isSimFinished={isFinished}
             />
           </div>
         </DndProvider>

--- a/src/components/notebook/chem-results.tsx
+++ b/src/components/notebook/chem-results.tsx
@@ -22,8 +22,8 @@ export const ChemResults: React.FC<IProps> = (props) => {
       <div className="results">
         {chemistryTests.map((test, index) => {
           const testResult = chemistryTestResults.find((result) => result.type === test.type);
-          const complete = testResult?.stepsComplete === test.steps.length;
           const testValue = test.results.find((res) => res.value === testResult?.value);
+          const complete = testResult?.value !== undefined && testResult?.stepsComplete === test.steps.length;
           const ratingType = testValue?.rating;
           const rating = chemTestRatings.find((r) => r.type === ratingType);
           const started = testResult ? testResult.stepsComplete > 0 : false;

--- a/src/components/notebook/chem-test-slider.scss
+++ b/src/components/notebook/chem-test-slider.scss
@@ -5,15 +5,30 @@
   height: 88px;
   bottom: 0;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 150px;
+  flex-direction: row;
+  align-items: flex-start;
+  min-width: 150px;
+
+  .slider-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .slider-units {
+    font-size: 12px;
+    font-weight: bold;
+    font-style: italic;
+    margin: 3px 0 0 6px;
+  }
 
   .slider-values {
     display: flex;
     justify-content: center;
     align-items: center;
     position: relative;
+    height: 45px;
+    flex-shrink: 0;
 
     .value-container {
       display: flex;
@@ -36,15 +51,6 @@
         border: solid 2px white;
         box-sizing: border-box;
       }
-    }
-
-    .slider-units {
-      position: absolute;
-      left: calc(100% + 5px);
-      top: 3px;
-      font-size: 12px;
-      font-weight: bold;
-      font-style: italic;
     }
   }
 

--- a/src/components/notebook/chem-test-slider.tsx
+++ b/src/components/notebook/chem-test-slider.tsx
@@ -21,30 +21,33 @@ export const ChemTestSlider: React.FC<IProps> = (props) => {
 
   return (
     <div className="chem-slider" data-testid="chem-slider">
-      <div className="slider-values">
-        { testValues.map((val, index) =>
-          <div className={`value-container ${sliderValue === index ? "selected" : ""}`} key={`value-${val.value}`}>
-            {val.value}
-            <div className="bubble" style={{backgroundColor: val.color, borderColor: sliderValue === index ? "black" : "white"}}>
-              {val.Icon && <val.Icon className="slider-icon" width={21} />}
+      <div className="slider-container">
+        <div className="slider-values">
+          { testValues.map((val, index) =>
+            <div className={`value-container ${sliderValue === index ? "selected" : ""}`} key={`value-${val.value}`}>
+              {val.value}
+              <div className="bubble" style={{backgroundColor: val.color,
+                                              borderColor: sliderValue === index ? "black" : (val?.borderColor || "white")}}>
+                {val.Icon && <val.Icon className="slider-icon" width={21} />}
+              </div>
             </div>
-          </div>
-        )}
-        <div className="slider-units">{units}</div>
+          )}
+        </div>
+        <div className="slider" style={{width: kSliderValWidth * (testValues.length - 1)}}>
+          <Slider
+            classes={{thumb: "thumb" }}
+            min={0}
+            max={testValues.length - 1}
+            value={sliderValue}
+            step={1}
+            marks={sliderMarks}
+            onChange={onChangeSlider}
+            ThumbComponent={IconHorizontalHandle as any}
+            data-test="chem-test-slider"
+          />
+        </div>
       </div>
-      <div className="slider" style={{width: kSliderValWidth * (testValues.length - 1)}}>
-        <Slider
-          classes={{thumb: "thumb" }}
-          min={0}
-          max={testValues.length - 1}
-          value={sliderValue}
-          step={1}
-          marks={sliderMarks}
-          onChange={onChangeSlider}
-          ThumbComponent={IconHorizontalHandle as any}
-          data-test="chem-test-slider"
-        />
-      </div>
+      <div className="slider-units">{units}</div>
     </div>
   );
 };

--- a/src/components/notebook/chem-test.scss
+++ b/src/components/notebook/chem-test.scss
@@ -95,6 +95,7 @@
       }
       &:active {
         background-color: $chemistry-blue-dark2;
+        box-shadow: none;
       }
 
       &.disabled {
@@ -105,6 +106,14 @@
         pointer-events: none;
         border: solid 1px $gray-dark25;
         color: $gray-dark2;
+        box-shadow: none;
+      }
+      &.running {
+        pointer-events: none;
+        border: solid 1px $gray-dark;
+        color: $gray-dark;
+        opacity: 1;
+        background-color: $chemistry-blue-dark2;
         box-shadow: none;
       }
 

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -106,7 +106,8 @@ export const ChemTest: React.FC<IProps> = (props) => {
                                                 index > stepsComplete) ||
                                                 ((index === stepsComplete) &&
                                                   (index === testResult.current?.currentStep)),
-                                      finished: index < stepsComplete })}
+                                      finished: index < stepsComplete,
+                                      running: index === testResult.current?.currentStep && index === stepsComplete})}
               key={`${chemistryTest.type}-step-button-${index}`}
               onClick={() => handleStepButtonClick(step, index + 1)}
             >

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -18,11 +18,10 @@ interface IProps {
   chemistryValues?: ChemistryValues;
   chemistryTestResults: ChemistryTestResult[];
   onUpdateTestResult: ({type, currentStep, stepsComplete, value}: IUpdateChemistryTestResult) => void;
-  isSimFinished: boolean;
 }
 
 export const ChemTest: React.FC<IProps> = (props) => {
-  const { chemistryTest, testIndex, chemistryValues, chemistryTestResults, onUpdateTestResult, isSimFinished } = props;
+  const { chemistryTest, testIndex, chemistryValues, chemistryTestResults, onUpdateTestResult } = props;
   const testResult = useCurrent(chemistryTestResults.find((result) => result.type === chemistryTest.type));
   const currentStep = testResult.current?.currentStep;
   const stepsComplete = testResult.current?.stepsComplete ?? 0;
@@ -102,8 +101,7 @@ export const ChemTest: React.FC<IProps> = (props) => {
           {chemistryTest.steps.map((step, index) =>
             <button
               className={classNames("step-button", {
-                                      disabled: (!isSimFinished ||
-                                                index > stepsComplete) ||
+                                      disabled: (index > stepsComplete) ||
                                                 ((index === stepsComplete) &&
                                                   (index === testResult.current?.currentStep)),
                                       finished: index < stepsComplete,

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -18,10 +18,11 @@ interface IProps {
   chemistryValues?: ChemistryValues;
   chemistryTestResults: ChemistryTestResult[];
   onUpdateTestResult: ({type, currentStep, stepsComplete, value}: IUpdateChemistryTestResult) => void;
+  isSimFinished: boolean;
 }
 
 export const ChemTest: React.FC<IProps> = (props) => {
-  const { chemistryTest, testIndex, chemistryValues, chemistryTestResults, onUpdateTestResult } = props;
+  const { chemistryTest, testIndex, chemistryValues, chemistryTestResults, onUpdateTestResult, isSimFinished } = props;
   const testResult = useCurrent(chemistryTestResults.find((result) => result.type === chemistryTest.type));
   const currentStep = testResult.current?.currentStep;
   const stepsComplete = testResult.current?.stepsComplete ?? 0;
@@ -101,7 +102,8 @@ export const ChemTest: React.FC<IProps> = (props) => {
           {chemistryTest.steps.map((step, index) =>
             <button
               className={classNames("step-button", {
-                                      disabled: (index > stepsComplete) ||
+                                      disabled: (!isSimFinished ||
+                                                index > stepsComplete) ||
                                                 ((index === stepsComplete) &&
                                                   (index === testResult.current?.currentStep)),
                                       finished: index < stepsComplete })}
@@ -118,7 +120,7 @@ export const ChemTest: React.FC<IProps> = (props) => {
               }
             </button>
           )}
-          {testResult.current?.value != null &&
+          {testResult.current &&
             ((currentStepInfo?.type === StepType.resultSlider) || (currentStepInfo?.type === StepType.tempDisplay)) &&
             <InputResult
               chemistryTest={chemistryTest}

--- a/src/components/notebook/chemistry-panel.tsx
+++ b/src/components/notebook/chemistry-panel.tsx
@@ -11,11 +11,10 @@ interface IProps {
   chemistryValues?: ChemistryValues;
   chemistryTestResults: ChemistryTestResult[];
   onUpdateTestResult: ({type, currentStep, stepsComplete, value}: IUpdateChemistryTestResult) => void;
-  isSimFinished: boolean;
 }
 
 export const ChemistryPanel: React.FC<IProps> = (props) => {
-  const { chemistryValues, chemistryTestResults, onUpdateTestResult, isSimFinished } = props;
+  const { chemistryValues, chemistryTestResults, onUpdateTestResult } = props;
   const [currentSection, setCurrentSection] = useState(0);
 
   // one extra page for the result summary
@@ -34,7 +33,6 @@ export const ChemistryPanel: React.FC<IProps> = (props) => {
               chemistryValues={chemistryValues}
               chemistryTestResults={chemistryTestResults}
               onUpdateTestResult={onUpdateTestResult}
-              isSimFinished={isSimFinished}
             />
         }
       </div>

--- a/src/components/notebook/chemistry-panel.tsx
+++ b/src/components/notebook/chemistry-panel.tsx
@@ -11,11 +11,11 @@ interface IProps {
   chemistryValues?: ChemistryValues;
   chemistryTestResults: ChemistryTestResult[];
   onUpdateTestResult: ({type, currentStep, stepsComplete, value}: IUpdateChemistryTestResult) => void;
-  isRunning: boolean;
+  isSimFinished: boolean;
 }
 
 export const ChemistryPanel: React.FC<IProps> = (props) => {
-  const { chemistryValues, chemistryTestResults, onUpdateTestResult } = props;
+  const { chemistryValues, chemistryTestResults, onUpdateTestResult, isSimFinished } = props;
   const [currentSection, setCurrentSection] = useState(0);
 
   // one extra page for the result summary
@@ -34,6 +34,7 @@ export const ChemistryPanel: React.FC<IProps> = (props) => {
               chemistryValues={chemistryValues}
               chemistryTestResults={chemistryTestResults}
               onUpdateTestResult={onUpdateTestResult}
+              isSimFinished={isSimFinished}
             />
         }
       </div>

--- a/src/components/notebook/habitat-panel.tsx
+++ b/src/components/notebook/habitat-panel.tsx
@@ -12,7 +12,6 @@ interface IProps {
   environment: EnvironmentType;
   featureSelections: Set<HabitatFeatureType>;
   onSelectFeature: (feture: HabitatFeatureType, selected: boolean) => void;
-  isRunning: boolean;
 }
 
 export const HabitatPanel: React.FC<IProps> = (props) => {

--- a/src/components/notebook/input-result.scss
+++ b/src/components/notebook/input-result.scss
@@ -33,7 +33,7 @@
       height: 23px;
       border-radius: 4px;
       margin-left: 3px;
-      background-color: $macro-score-pink;
+      background-color: white;
     }
   }
 }

--- a/src/components/notebook/input-result.tsx
+++ b/src/components/notebook/input-result.tsx
@@ -19,9 +19,11 @@ export const InputResult: React.FC<IProps> = (props) => {
     <div className="input-result">
       {t("CHEM.RESULT")}
       <div className="current-result">
-        <div className="test-result">{`${chemistryTestResult?.value} ${chemistryTest.units}`}</div>
-        {rating && <div>=</div>}
-        {rating && <div className="test-rating" style={{backgroundColor: rating.color}}>{rating.label}</div>}
+        <div className="test-result">
+          {chemistryTestResult?.value !== undefined ? `${chemistryTestResult?.value} ${chemistryTest.units}` : ""}
+        </div>
+        <div>=</div>
+        <div className="test-rating" style={{backgroundColor: rating?.color}}>{rating ? rating.label : ""}</div>
       </div>
     </div>
   );

--- a/src/components/notebook/input-result.tsx
+++ b/src/components/notebook/input-result.tsx
@@ -15,6 +15,7 @@ export const InputResult: React.FC<IProps> = (props) => {
   const testValue = chemistryTest.results.find((res) => res.value === chemistryTestResult?.value);
   const ratingType = testValue?.rating;
   const rating = chemTestRatings.find((r) => r.type === ratingType);
+  const testHasRating = chemistryTest.results[0]?.rating;
   return (
     <div className="input-result">
       {t("CHEM.RESULT")}
@@ -22,8 +23,8 @@ export const InputResult: React.FC<IProps> = (props) => {
         <div className="test-result">
           {chemistryTestResult?.value !== undefined ? `${chemistryTestResult?.value} ${chemistryTest.units}` : ""}
         </div>
-        <div>=</div>
-        <div className="test-rating" style={{backgroundColor: rating?.color}}>{rating ? rating.label : ""}</div>
+        {testHasRating && <div>=</div>}
+        {testHasRating && <div className="test-rating" style={{backgroundColor: rating?.color}}>{rating ? rating.label : ""}</div>}
       </div>
     </div>
   );

--- a/src/components/notebook/macro-panel.tsx
+++ b/src/components/notebook/macro-panel.tsx
@@ -9,7 +9,6 @@ import "./macro-panel.scss";
 const kCrittersPerSection = 5;
 
 interface IProps {
-  isRunning: boolean;
   trayObjects: TrayObject[];
   onCategorizeAnimal: (trayType: TrayType | undefined, notebookType: TrayType | undefined) => void;
   traySelectionType?: TrayType;

--- a/src/components/notebook/notebook.tsx
+++ b/src/components/notebook/notebook.tsx
@@ -25,12 +25,12 @@ interface IProps {
   chemistryTestResults: ChemistryTestResult[];
   onUpdateTestResult: ({type, currentStep, stepsComplete, value}: IUpdateChemistryTestResult) => void;
   traySelectionType?: TrayType;
-  isRunning: boolean;
+  isSimFinished: boolean;
 }
 
 export const Notebook: React.FC<IProps> = (props) => {
   const { trayObjects, environment, featureSelections, onSelectFeature, onCategorizeAnimal, traySelectionType,
-          isRunning, ...chemistryProps } = props;
+          isSimFinished, ...chemistryProps } = props;
   return (
     <div className="notebook" data-testid="notebook">
       <Tabs>
@@ -51,7 +51,6 @@ export const Notebook: React.FC<IProps> = (props) => {
             environment={environment}
             featureSelections={featureSelections}
             onSelectFeature={onSelectFeature}
-            isRunning={isRunning}
           />
         </TabPanel>
         <TabPanel>
@@ -59,11 +58,10 @@ export const Notebook: React.FC<IProps> = (props) => {
             trayObjects={trayObjects}
             onCategorizeAnimal={onCategorizeAnimal}
             traySelectionType={traySelectionType}
-            isRunning={isRunning}
           />
         </TabPanel>
         <TabPanel>
-          <ChemistryPanel {...chemistryProps} isRunning={isRunning} />
+          <ChemistryPanel {...chemistryProps} isSimFinished={isSimFinished} />
         </TabPanel>
 
       </Tabs>

--- a/src/components/notebook/notebook.tsx
+++ b/src/components/notebook/notebook.tsx
@@ -25,12 +25,11 @@ interface IProps {
   chemistryTestResults: ChemistryTestResult[];
   onUpdateTestResult: ({type, currentStep, stepsComplete, value}: IUpdateChemistryTestResult) => void;
   traySelectionType?: TrayType;
-  isSimFinished: boolean;
 }
 
 export const Notebook: React.FC<IProps> = (props) => {
   const { trayObjects, environment, featureSelections, onSelectFeature, onCategorizeAnimal, traySelectionType,
-          isSimFinished, ...chemistryProps } = props;
+          ...chemistryProps } = props;
   return (
     <div className="notebook" data-testid="notebook">
       <Tabs>
@@ -61,7 +60,7 @@ export const Notebook: React.FC<IProps> = (props) => {
           />
         </TabPanel>
         <TabPanel>
-          <ChemistryPanel {...chemistryProps} isSimFinished={isSimFinished} />
+          <ChemistryPanel {...chemistryProps} />
         </TabPanel>
 
       </Tabs>

--- a/src/hooks/use-leaf-model-state.ts
+++ b/src/hooks/use-leaf-model-state.ts
@@ -28,7 +28,7 @@ export const useLeafModelState = (props: IProps) => {
                           chemistryTestResults: [
                             {type: ChemTestType.airTemperature, stepsComplete: 0},
                             {type: ChemTestType.waterTemperature, stepsComplete: 0},
-                            {type: ChemTestType.pH, stepsComplete: 0, value: 0},
+                            {type: ChemTestType.pH, stepsComplete: 0},
                             {type: ChemTestType.nitrate, stepsComplete: 0},
                             {type: ChemTestType.turbidity, stepsComplete: 0},
                             {type: ChemTestType.dissolvedOxygen, stepsComplete: 0}

--- a/src/leaf-model-types.ts
+++ b/src/leaf-model-types.ts
@@ -1,4 +1,4 @@
-import { ChemistryTestResult, ChemistryValues } from "./utils/chem-types";
+import { ChemistryTestResult } from "./utils/chem-types";
 import { EnvironmentType } from "./utils/environment";
 import { HabitatFeatureType } from "./utils/habitat-utils";
 import {
@@ -21,7 +21,6 @@ export interface IModelOutputState {
   trayObjects: TrayObject[];
   pti?: number;
   habitatFeatures: Set<HabitatFeatureType>;
-  chemistryValues?: ChemistryValues;
   chemistryTestResults: ChemistryTestResult[];
 }
 export interface IModelTransientState {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,4 @@
 import { IModelInputState } from "./leaf-model-types";
-import { chemistryFinalValues } from "./utils/chem-utils";
 import { EnvironmentType } from "./utils/environment";
 import { LeafDecompositionType, LeafEatersAmountType, AlgaeEatersAmountType, FishAmountType, Animal, Animals,
          AnimalInstance, LeafDecompositionFinalValues, LeafEatersFinalValues, AlgaeEatersFinalValues, FishFinalValues,
@@ -115,7 +114,6 @@ export class Model {
       algaeEaters,
       fish,
       animalInstances: this.animalInstances,
-      chemistryValues: chemistryFinalValues[this.environment]
     };
   }
 }

--- a/src/utils/chem-types.ts
+++ b/src/utils/chem-types.ts
@@ -46,6 +46,7 @@ export interface ChemTestValue {
   value: number;
   rating?: ChemTestRatingType;
   color?: string;
+  borderColor?: string;
   Icon?: React.FC<SVGProps<SVGSVGElement>>;
   frames?: Record<string, React.FC<SVGProps<SVGSVGElement>>>;
 }


### PR DESCRIPTION
This PR adds a series of small fixes to the chem lab in the notebook. Changes include:
- test results do not show in results home section until the user enters a value using the slider.
- the test result container is displayed for each individual test as soon as the slider is shown.  The result container is empty until  the user enters a value using the slider.
- the sliders do not change position when user sets value 
- test buttons appear with styling consistent with UI spec (blue background) when test animation is running
- user can run tests without having run the simulation (we will need to preserve the test results just as we do the habitat selections)
- slider positioning has been fixed so it no longer overlaps test step buttons
- dissolved oxygen and nitrate slider value bubbles now have a gray border around 0 value so they are easier to read