### PR TITLE
Clarify TypeScript types

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -12,7 +12,7 @@ import { Notebook } from "./notebook/notebook";
 import { Tray } from "./simulation/tray";
 // import { ModalDialog } from "./modal-dialog";
 import { ContainerId, useLeafModelState } from "../hooks/use-leaf-model-state";
-import { IModelConfig, IModelInputState, IModelOutputState } from "../leaf-model-types";
+import { ILeafModelConfig, ILeafModelInputState, ILeafModelOutputState } from "../leaf-model-types";
 import { Model } from "../model";
 import { ChemistryTestResult, IUpdateChemistryTestResult } from "../utils/chem-types";
 import { chemistryTests, chemistryFinalValues } from "../utils/chem-utils";
@@ -23,7 +23,9 @@ import {
 } from "../utils/sim-utils";
 import { HabitatFeatureType } from "../utils/habitat-utils";
 import { getPTIScore } from "../utils/macro-utils";
-import { calculateRotatedBoundingBox, calculateBoundedPosition, getRandomInteger, shuffleArray } from "../utils/math-utils";
+import {
+  calculateRotatedBoundingBox, calculateBoundedPosition, getRandomInteger, shuffleArray
+} from "../utils/math-utils";
 import t from "../utils/translation/translate";
 
 import "./app.scss";
@@ -37,7 +39,7 @@ const kSelectedContainerBgColor = "#f5f5f5";
 // Modal.setAppElement("#app");
 
 // TODO: some of these app props are likely not needed
-export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModelConfig>> = (appProps) => {
+export const App: React.FC<IAppProps<ILeafModelInputState, ILeafModelOutputState, ILeafModelConfig>> = (appProps) => {
   const { logEvent } = appProps;
   const modelState = useLeafModelState(appProps);
   const {inputState, setInputState,
@@ -157,7 +159,7 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
     setInputState({environment: environmentForContainerId[containerId]});
   };
 
-  const thumbnailChooserProps: IThumbnailChooserProps<IModelInputState, IModelOutputState> = {
+  const thumbnailChooserProps: IThumbnailChooserProps<ILeafModelInputState, ILeafModelOutputState> = {
     Thumbnail,
     disableUnselectedThumbnails: isRunning,
     containers,
@@ -189,7 +191,7 @@ export const App: React.FC<IAppProps<IModelInputState, IModelOutputState, IModel
 
   const leafPackState = LeafPackStates.find((ls) => ls.leafDecomposition === leafDecomposition) || LeafPackStates[0];
 
-  const setOutputStateAndSave = (output: Partial<IModelOutputState>) => {
+  const setOutputStateAndSave = (output: Partial<ILeafModelOutputState>) => {
     const pti = output.trayObjects ? { pti: getPTIScore(output.trayObjects) }: undefined;
     setOutputState({ ...output, ...pti });
   };

--- a/src/components/thumbnail/thumbnail.test.tsx
+++ b/src/components/thumbnail/thumbnail.test.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { Thumbnail } from "./thumbnail";
 import { IContainer } from "../../hooks/use-model-state";
-import { IModelInputState, IModelOutputState } from "../../leaf-model-types";
+import { ILeafModelInputState, ILeafModelOutputState } from "../../leaf-model-types";
 import { EnvironmentType } from "../../utils/environment";
 import { AlgaeEatersAmountType, FishAmountType, LeafDecompositionType, LeafEatersAmountType } from "../../utils/sim-utils";
 
 describe("Thumbnail component", () => {
-  const emptyContainer: IContainer<IModelInputState, IModelOutputState> = {
+  const emptyContainer: IContainer<ILeafModelInputState, ILeafModelOutputState> = {
     inputState: { environment: EnvironmentType.environment1, sunnyDayFequency: 0 },
     outputState: {
       leafDecomposition: LeafDecompositionType.little,

--- a/src/components/thumbnail/thumbnail.tsx
+++ b/src/components/thumbnail/thumbnail.tsx
@@ -5,12 +5,12 @@ import IconHabitatNotebook from "../../assets/habitat-icon.svg";
 import IconMacroinvertebratesNotebook from "../../assets/macro-icon.svg";
 import IconPTI from "../../assets/pti-icon.svg";
 import IconSun from "../../assets/sunny-icon.svg";
-import { IModelInputState, IModelOutputState } from "../../leaf-model-types";
+import { ILeafModelInputState, ILeafModelOutputState } from "../../leaf-model-types";
 import t from "../../utils/translation/translate";
 
 import "./thumbnail.scss";
 
-export const Thumbnail: React.FC<IThumbnailProps<IModelInputState, IModelOutputState>> = (props) => {
+export const Thumbnail: React.FC<IThumbnailProps<ILeafModelInputState, ILeafModelOutputState>> = (props) => {
   const {inputState: {sunnyDayFequency},
         outputState: {habitatFeatures, pti, chemistryTestResults}} = props.container;
   const showHabitatIcon = habitatFeatures.size > 0;

--- a/src/hooks/use-leaf-model-state.ts
+++ b/src/hooks/use-leaf-model-state.ts
@@ -1,18 +1,22 @@
 import { IAppProps } from "../components/render-app";
-import { IModelConfig, IModelInputState, IModelOutputState, IModelTransientState } from "../leaf-model-types";
+import {
+  ILeafModelConfig, ILeafModelInputState, ILeafModelOutputState, ILeafModelTransientState
+} from "../leaf-model-types";
 import { ChemTestType } from "../utils/chem-types";
 import { EnvironmentType } from "../utils/environment";
-import { AlgaeEatersAmountType, FishAmountType, LeafDecompositionType, LeafEatersAmountType } from "../utils/sim-utils";
+import {
+  AlgaeEatersAmountType, FishAmountType, LeafDecompositionType, LeafEatersAmountType
+} from "../utils/sim-utils";
 import useModelState, { ContainerId, hasOwnProperties, IModelCurrentState } from "./use-model-state";
 
 export { ContainerId };
 
-const isValidExternalState = (newState: IModelCurrentState<IModelInputState, IModelOutputState>) => {
+const isValidExternalState = (newState: IModelCurrentState<ILeafModelInputState, ILeafModelOutputState>) => {
   return hasOwnProperties(newState.inputState, ["environment", "sunnyDayFequency"]) &&
           hasOwnProperties(newState.outputState, ["leafDecomposition", "leafEaters", "algaeEaters", "fish", "animalInstances"]);
 };
 
-const defaultOutputState: IModelOutputState = {
+const defaultOutputState: ILeafModelOutputState = {
   leafDecomposition: LeafDecompositionType.little,
   leafEaters: LeafEatersAmountType.few,
   algaeEaters: AlgaeEatersAmountType.few,
@@ -31,10 +35,10 @@ const defaultOutputState: IModelOutputState = {
   habitatFeatures: new Set()
 };
 
-interface IProps extends IAppProps<IModelInputState, IModelOutputState, IModelConfig> {
+interface IProps extends IAppProps<ILeafModelInputState, ILeafModelOutputState, ILeafModelConfig> {
 }
 export const useLeafModelState = (props: IProps) => {
-  return useModelState<IModelInputState, IModelOutputState, IModelTransientState>({
+  return useModelState<ILeafModelInputState, ILeafModelOutputState, ILeafModelTransientState>({
     initialInputState: { environment: EnvironmentType.environment1, sunnyDayFequency: 0 },
     initialOutputState: {
       A: defaultOutputState,
@@ -49,6 +53,11 @@ export const useLeafModelState = (props: IProps) => {
       time: 1
     },
     isValidExternalState,
+    rewindOutputState: (initialOutputState: ILeafModelOutputState, outputState: ILeafModelOutputState) => {
+      // preserve parts of output state that persist through rewind
+      const { trayObjects, pti, habitatFeatures, chemistryTestResults } = outputState;
+      return { ...initialOutputState, ...{ trayObjects, pti, habitatFeatures, chemistryTestResults } };
+    },
     ...props
   });
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,19 +1,19 @@
 import { App} from "./components/app";
 import { renderApp } from "./components/render-app";
 import { IModelCurrentState } from "./hooks/use-model-state";
-import { IModelInputState, IModelOutputState, IModelConfig } from "./leaf-model-types";
+import { ILeafModelInputState, ILeafModelOutputState, ILeafModelConfig } from "./leaf-model-types";
 import { deserialize, SerializableModelState, serialize } from "./utils/serialize-utils";
 import { getInitInteractiveMessage, setInteractiveState } from "@concord-consortium/lara-interactive-api";
 
 import "./index.scss";
 
-const app = renderApp<IModelInputState, IModelOutputState, IModelConfig>({App, logEvent, modelConfig: {}, onStateChange: handleStateChange});
+const app = renderApp<ILeafModelInputState, ILeafModelOutputState, ILeafModelConfig>({App, logEvent, modelConfig: {}, onStateChange: handleStateChange});
 
 function logEvent(args: any) {
   // do nothing
 }
 
-function handleStateChange(newState: IModelCurrentState<IModelInputState, IModelOutputState>) {
+function handleStateChange(newState: IModelCurrentState<ILeafModelInputState, ILeafModelOutputState>) {
   setInteractiveState(serialize(newState));
 }
 

--- a/src/leaf-model-types.ts
+++ b/src/leaf-model-types.ts
@@ -27,7 +27,7 @@ export interface ILeafModelTransientState {
   time: number;
 }
 export interface ISerializableTrayObject extends Omit<TrayObject, "image" | "dragImage" | "selectionPath" | "width" | "height"> {}
-export interface ISerializableModelOutputState extends Omit<ILeafModelOutputState, "trayObjects" | "habitatFeatures">  {
+export interface ISerializableLeafModelOutputState extends Omit<ILeafModelOutputState, "trayObjects" | "habitatFeatures">  {
   trayObjects: ISerializableTrayObject[];
   habitatFeatures: string[];
 }

--- a/src/leaf-model-types.ts
+++ b/src/leaf-model-types.ts
@@ -6,12 +6,12 @@ import {
   LeafDecompositionType, LeafEatersAmountType, TrayObject
 } from "./utils/sim-utils";
 
-export interface IModelConfig {}
-export interface IModelInputState {
+export interface ILeafModelConfig {}
+export interface ILeafModelInputState {
   environment: EnvironmentType;
   sunnyDayFequency: number;
 }
-export interface IModelOutputState {
+export interface ILeafModelOutputState {
   leafDecomposition: LeafDecompositionType;
   leafEaters: LeafEatersAmountType;
   algaeEaters: AlgaeEatersAmountType;
@@ -23,11 +23,11 @@ export interface IModelOutputState {
   habitatFeatures: Set<HabitatFeatureType>;
   chemistryTestResults: ChemistryTestResult[];
 }
-export interface IModelTransientState {
+export interface ILeafModelTransientState {
   time: number;
 }
 export interface ISerializableTrayObject extends Omit<TrayObject, "image" | "dragImage" | "selectionPath" | "width" | "height"> {}
-export interface ISerializableModelOutputState extends Omit<IModelOutputState, "trayObjects" | "habitatFeatures">  {
+export interface ISerializableModelOutputState extends Omit<ILeafModelOutputState, "trayObjects" | "habitatFeatures">  {
   trayObjects: ISerializableTrayObject[];
   habitatFeatures: string[];
 }

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -1,9 +1,9 @@
-import { IModelInputState } from "./leaf-model-types";
+import { ILeafModelInputState } from "./leaf-model-types";
 import { Model, kMaxSteps } from "./model";
 import { EnvironmentType } from "./utils/environment";
 
 describe("model", () => {
-  let inputState: IModelInputState;
+  let inputState: ILeafModelInputState;
   let model: Model;
 
   beforeEach(() => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { IModelInputState } from "./leaf-model-types";
+import { ILeafModelInputState } from "./leaf-model-types";
 import { EnvironmentType } from "./utils/environment";
 import { LeafDecompositionType, LeafEatersAmountType, AlgaeEatersAmountType, FishAmountType, Animal, Animals,
          AnimalInstance, LeafDecompositionFinalValues, LeafEatersFinalValues, AlgaeEatersFinalValues, FishFinalValues,
@@ -14,7 +14,7 @@ export class Model {
   private sunnyDayFequency = 0;
   private animalInstances: AnimalInstance[] = [];
 
-  constructor(inputState: IModelInputState) {
+  constructor(inputState: ILeafModelInputState) {
     this.environment = inputState.environment;
     this.sunnyDayFequency = inputState.sunnyDayFequency;
     this.animalInstances = [];

--- a/src/utils/serialize-utils.test.ts
+++ b/src/utils/serialize-utils.test.ts
@@ -1,4 +1,4 @@
-import { IModelInputState, IModelOutputState } from "../leaf-model-types";
+import { ILeafModelInputState, ILeafModelOutputState } from "../leaf-model-types";
 import { EnvironmentType } from "./environment";
 import { AlgaeEatersAmountType, AnimalType, FishAmountType, LeafDecompositionType, LeafEatersAmountType } from "./sim-utils";
 import { aquaticWormSelectionPath } from "./selection-utils";
@@ -9,10 +9,10 @@ import { ChemTestType } from "./chem-types";
 import { deserialize, SerializableModelState, serialize } from "./serialize-utils";
 import { IModelCurrentState } from "../hooks/use-model-state";
 
-type ModelState = IModelCurrentState<IModelInputState, IModelOutputState>;
+type ModelState = IModelCurrentState<ILeafModelInputState, ILeafModelOutputState>;
 
-const inputState: IModelInputState = { environment: EnvironmentType.environment1, sunnyDayFequency: 0 };
-const outputState: IModelOutputState = {
+const inputState: ILeafModelInputState = { environment: EnvironmentType.environment1, sunnyDayFequency: 0 };
+const outputState: ILeafModelOutputState = {
   leafDecomposition: LeafDecompositionType.little,
   leafEaters: LeafEatersAmountType.few,
   algaeEaters: AlgaeEatersAmountType.few,

--- a/src/utils/serialize-utils.ts
+++ b/src/utils/serialize-utils.ts
@@ -1,15 +1,15 @@
 import { ContainerId, ContainerIds, IContainer, IContainerMap, IModelCurrentState, initContainerMap, IPartialContainerMap } from "../hooks/use-model-state";
-import { ILeafModelInputState, ILeafModelOutputState, ISerializableModelOutputState, ISerializableTrayObject } from "../leaf-model-types";
+import { ILeafModelInputState, ILeafModelOutputState, ISerializableLeafModelOutputState, ISerializableTrayObject } from "../leaf-model-types";
 import { Animal, Animals, Leaf, Leaves, TrayObject } from "./sim-utils";
 import { HabitatFeatureType } from "./habitat-utils";
 import cloneDeep from "lodash.clonedeep";
 
 type ModelState = IModelCurrentState<ILeafModelInputState, ILeafModelOutputState>;
-export type SerializableModelState = IModelCurrentState<ILeafModelInputState, ISerializableModelOutputState>;
+export type SerializableModelState = IModelCurrentState<ILeafModelInputState, ISerializableLeafModelOutputState>;
 type ContainerState = IContainer<ILeafModelInputState, ILeafModelOutputState>;
-type SerializableContainerMap = IContainerMap<ILeafModelInputState, ISerializableModelOutputState>;
+type SerializableContainerMap = IContainerMap<ILeafModelInputState, ISerializableLeafModelOutputState>;
 
-const serializeOutputState = (outputState: ILeafModelOutputState): ISerializableModelOutputState => {
+const serializeOutputState = (outputState: ILeafModelOutputState): ISerializableLeafModelOutputState => {
   const serializableTrayObjects: ISerializableTrayObject[] = outputState.trayObjects.map(trayObj => {
     const {image, dragImage, selectionPath, width, height, ...serializableTrayObject} = trayObj;
     return serializableTrayObject;
@@ -23,7 +23,7 @@ const serializeOutputState = (outputState: ILeafModelOutputState): ISerializable
   };
 };
 
-export const deserializeOutputState = (serializedOutputState: ISerializableModelOutputState): ILeafModelOutputState => {
+export const deserializeOutputState = (serializedOutputState: ISerializableLeafModelOutputState): ILeafModelOutputState => {
   const trayObjects = serializedOutputState.trayObjects.map(trayObj => {
     let baseObject: Animal | Leaf | undefined;
     baseObject = Animals.find(animal => animal.type === trayObj.type);
@@ -55,7 +55,7 @@ export const deserializeOutputState = (serializedOutputState: ISerializableModel
 export const serialize = (model: ModelState): SerializableModelState => {
   const clonedState = cloneDeep(model);
 
-  const serializableContainers: IPartialContainerMap<ILeafModelInputState, ISerializableModelOutputState> = {};
+  const serializableContainers: IPartialContainerMap<ILeafModelInputState, ISerializableLeafModelOutputState> = {};
   for (const id of ContainerIds) serializableContainers[id] = null;
 
   Object.keys(clonedState.containers).forEach((key: ContainerId) => {

--- a/src/utils/serialize-utils.ts
+++ b/src/utils/serialize-utils.ts
@@ -1,15 +1,15 @@
 import { ContainerId, ContainerIds, IContainer, IContainerMap, IModelCurrentState, initContainerMap, IPartialContainerMap } from "../hooks/use-model-state";
-import { IModelInputState, IModelOutputState, ISerializableModelOutputState, ISerializableTrayObject } from "../leaf-model-types";
+import { ILeafModelInputState, ILeafModelOutputState, ISerializableModelOutputState, ISerializableTrayObject } from "../leaf-model-types";
 import { Animal, Animals, Leaf, Leaves, TrayObject } from "./sim-utils";
 import { HabitatFeatureType } from "./habitat-utils";
 import cloneDeep from "lodash.clonedeep";
 
-type ModelState = IModelCurrentState<IModelInputState, IModelOutputState>;
-export type SerializableModelState = IModelCurrentState<IModelInputState, ISerializableModelOutputState>;
-type ContainerState = IContainer<IModelInputState, IModelOutputState>;
-type SerializableContainerMap = IContainerMap<IModelInputState, ISerializableModelOutputState>;
+type ModelState = IModelCurrentState<ILeafModelInputState, ILeafModelOutputState>;
+export type SerializableModelState = IModelCurrentState<ILeafModelInputState, ISerializableModelOutputState>;
+type ContainerState = IContainer<ILeafModelInputState, ILeafModelOutputState>;
+type SerializableContainerMap = IContainerMap<ILeafModelInputState, ISerializableModelOutputState>;
 
-const serializeOutputState = (outputState: IModelOutputState): ISerializableModelOutputState => {
+const serializeOutputState = (outputState: ILeafModelOutputState): ISerializableModelOutputState => {
   const serializableTrayObjects: ISerializableTrayObject[] = outputState.trayObjects.map(trayObj => {
     const {image, dragImage, selectionPath, width, height, ...serializableTrayObject} = trayObj;
     return serializableTrayObject;
@@ -23,7 +23,7 @@ const serializeOutputState = (outputState: IModelOutputState): ISerializableMode
   };
 };
 
-export const deserializeOutputState = (serializedOutputState: ISerializableModelOutputState): IModelOutputState => {
+export const deserializeOutputState = (serializedOutputState: ISerializableModelOutputState): ILeafModelOutputState => {
   const trayObjects = serializedOutputState.trayObjects.map(trayObj => {
     let baseObject: Animal | Leaf | undefined;
     baseObject = Animals.find(animal => animal.type === trayObj.type);
@@ -55,7 +55,7 @@ export const deserializeOutputState = (serializedOutputState: ISerializableModel
 export const serialize = (model: ModelState): SerializableModelState => {
   const clonedState = cloneDeep(model);
 
-  const serializableContainers: IPartialContainerMap<IModelInputState, ISerializableModelOutputState> = {};
+  const serializableContainers: IPartialContainerMap<ILeafModelInputState, ISerializableModelOutputState> = {};
   for (const id of ContainerIds) serializableContainers[id] = null;
 
   Object.keys(clonedState.containers).forEach((key: ContainerId) => {
@@ -76,7 +76,7 @@ export const serialize = (model: ModelState): SerializableModelState => {
 };
 
 export const deserialize = (serializableState: SerializableModelState): ModelState => {
-  const containers: IContainerMap<IModelInputState, IModelOutputState> = initContainerMap();
+  const containers: IContainerMap<ILeafModelInputState, ILeafModelOutputState> = initContainerMap();
 
   Object.keys(serializableState.containers).forEach((key: ContainerId) => {
     const container = serializableState.containers[key];


### PR DESCRIPTION
Previously, we had a set of TypeScript types (`IModelConfig`, `IModelInputState`, `IModelOutputState`, etc.) with identical names to a set of generic TypeScript parameters used to configure TypeScript objects inherited from DESE. This led to some confusion on the part of some sleep-deprived developers who shall remain nameless.

With this PR we rename the actual types used by the LeafPack simulation (`ILeafModelConfig`, `ILeafModelInputState`, `ILeafModelOutputState`) and separate the LeafPack-specific code that had crept into what should have been generic code. There are also some unit test improvements.