### PR TITLE
177011511 drag flicker

### DIFF
--- a/src/components/simulation/tray-image-preview.test.tsx
+++ b/src/components/simulation/tray-image-preview.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { TrayImagePreview } from "./tray-image-preview";
 import { AnimalType, TrayObject } from "../../utils/sim-utils";
+import caddisFlyImage from "../../assets/animals/caddisfly.svg";
 
 let callCount = 0;
 jest.mock("react-dnd-preview", () => ({
@@ -29,7 +30,7 @@ describe("TrayImagePreview component", () => {
     boundingBoxWidth: 60,
     boundingBoxHeight: 60,
     rotation: 0,
-    image: null,
+    image: caddisFlyImage,
     dragImage: null,
     selectionPath: "",
     zIndex: 1

--- a/src/components/simulation/tray-image-preview.tsx
+++ b/src/components/simulation/tray-image-preview.tsx
@@ -18,7 +18,7 @@ interface IProps {
   dragPosition: XYCoord | null;
 }
 export const TrayImagePreview: React.FC<IProps> = ({ trayWrapper, trayObject, dragSourcePosition, dragPosition }) => {
-  const {display, item} = usePreview();
+  const {display} = usePreview();
   if (!display || !dragSourcePosition || !dragPosition) {
     return null;
   }
@@ -35,6 +35,8 @@ export const TrayImagePreview: React.FC<IProps> = ({ trayWrapper, trayObject, dr
     previewStyle = {
       left: dragSourcePosition.x + boundingBoxDeltaX - kOutlineOffset,
       top: dragSourcePosition.y + boundingBoxDeltaY - kOutlineOffset,
+      width: trayObject.width,
+      height: trayObject.height,
       transform: `rotate(${trayObject.rotation}deg)`
     };
   } else {
@@ -45,5 +47,6 @@ export const TrayImagePreview: React.FC<IProps> = ({ trayWrapper, trayObject, dr
       top: dragPosition.y - previewHeight / 2,
     };
   }
-  return <img style={previewStyle} src={item.dragImage} className="preview" data-testid="preview" />;
+  const TrayObjectImage = trayObject.image;
+  return <TrayObjectImage className="preview" data-testid="preview" style={previewStyle} />;
 };


### PR DESCRIPTION
This PR uses the tray image SVG for the drag preview instead of relying on a separate PNG.  As a result, this seems to reduce drag flicker.  Note, that I will remove the `dragImage` from the tray object and remove all of the drag preview assets in a subsequent PR (which will reduce code complexity and massively reduce the number of needed assets).  However, I wanted to get this approved and merged before the planning meeting so this PR only includes the change to use the SVG over the PNG for the drag preview.

With the change, we do not see flicker when moving:
![no-flash-drag](https://user-images.githubusercontent.com/5126913/108893393-e8d1c200-75c5-11eb-8105-a5a530487913.gif)

In the old version that used the PNG, we see flicker when items are moved:
![flash-drag](https://user-images.githubusercontent.com/5126913/108893330-d22b6b00-75c5-11eb-8142-0fe9255ba006.gif)
