### PR TITLE
Fix implementation of habitatFeatures [#177070719]

### DIFF
--- a/src/hooks/use-leaf-model-state.test.ts
+++ b/src/hooks/use-leaf-model-state.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { ILeafModelInputState, ILeafModelOutputState } from "../leaf-model-types";
+import { HabitatFeatureType } from "../utils/habitat-utils";
+import { FishAmountType } from "../utils/sim-utils";
+import { isValidExternalState, useLeafModelState } from "./use-leaf-model-state";
+import { IModelCurrentState } from "./use-model-state";
+
+describe("useLeafModelState", () => {
+
+  const onStateChange = jest.fn();
+  const addExternalSetStateListener = jest.fn();
+  const removeExternalSetStateListener = jest.fn();
+  const logEvent = jest.fn();
+
+  test("works as expected", () => {
+    const { result, rerender } = renderHook(() =>
+      useLeafModelState({
+        onStateChange,
+        addExternalSetStateListener,
+        removeExternalSetStateListener,
+        logEvent,
+        modelConfig: {}
+      }));
+    expect(result.current.selectedContainerId).toBe("A");
+    expect(result.current.outputState.fish).toBe(FishAmountType.few);
+    expect(result.current.outputState.habitatFeatures.has(HabitatFeatureType.pools)).toBe(false);
+
+    const validCurrentState: IModelCurrentState<ILeafModelInputState, ILeafModelOutputState> = {
+      inputState: result.current.inputState,
+      outputState: result.current.outputState,
+      containers: result.current.containers,
+      selectedContainerId: result.current.selectedContainerId
+    };
+    expect(isValidExternalState(validCurrentState)).toBe(true);
+
+    act(() => {
+      result.current.setOutputState({ habitatFeatures: new Set([HabitatFeatureType.pools]) });
+    });
+    expect(result.current.outputState.habitatFeatures.has(HabitatFeatureType.pools)).toBe(true);
+
+    act(() => {
+      result.current.rewindSimulation();
+      rerender();
+    });
+    // habitat features are preserved through rewind
+    expect(result.current.outputState.habitatFeatures.has(HabitatFeatureType.pools)).toBe(true);
+
+    act(() => {
+      result.current.setSelectedContainerId("D");
+      rerender();
+    });
+    // habitat features are not preserved across containers
+    expect(result.current.outputState.habitatFeatures.has(HabitatFeatureType.pools)).toBe(false);
+    // initial fish value is reset when switching containers
+    expect(result.current.outputState.fish).toBe(FishAmountType.none);
+  });
+
+});

--- a/src/hooks/use-model-state.test.ts
+++ b/src/hooks/use-model-state.test.ts
@@ -16,20 +16,14 @@ interface IModelTransientState {
   baz: number;
 }
 
-const initialInputState: IModelInputState = {
+const initialInputState = (): IModelInputState => ({
   foo: true,
   bar: "boom"
-};
+});
 
-const initialOutputState: IModelOutputState = {
+const initialOutputState = (): IModelOutputState => ({
   bam: 10
-};
-const initialOutputStateMap: Record<ContainerId, IModelOutputState> = {
-  A: initialOutputState,
-  B: initialOutputState,
-  C: initialOutputState,
-  D: initialOutputState
-};
+});
 
 const initialTransientState: IModelTransientState = {
   baz: 0
@@ -57,8 +51,9 @@ describe("useModelState", () => {
     mockSimulationStep = jest.fn();
 
     HookWrapper = () => useModelState<IModelInputState, IModelOutputState, IModelTransientState>({
+      initialContainerId: "A",
       initialInputState,
-      initialOutputState: initialOutputStateMap,
+      initialOutputState,
       initialTransientState,
       finalTransientState,
       onStateChange,
@@ -93,8 +88,8 @@ describe("useModelState", () => {
       isSaved,
       isSimulationRunning,
     } = result.current;
-    expect(inputState).toEqual(initialInputState);
-    expect(outputState).toEqual(initialOutputState);
+    expect(inputState).toEqual(initialInputState());
+    expect(outputState).toEqual(initialOutputState());
     expect(transientState).toEqual(initialTransientState);
     expect(simulationState).toEqual(initialSimulationState);
     expect(selectedContainerId).toEqual("A");
@@ -111,13 +106,13 @@ describe("useModelState", () => {
     act(() => {
       result.current.setInputState({foo: false});
     });
-    expect(result.current.inputState).toEqual({...initialInputState, foo: false});
+    expect(result.current.inputState).toEqual({...initialInputState(), foo: false});
     expect(result.current.isDirty).toEqual(true);
 
     act(() => {
       result.current.setOutputState({bam: 100});
     });
-    expect(result.current.outputState).toEqual({...initialOutputState, bam: 100});
+    expect(result.current.outputState).toEqual({...initialOutputState(), bam: 100});
 
     act(() => {
       result.current.setTransientState({baz: 10000});
@@ -210,8 +205,9 @@ describe("useModelState", () => {
     const mockRewind = jest.fn();
 
     HookWrapper = () => useModelState<IModelInputState, IModelOutputState, IModelTransientState>({
+      initialContainerId: "A",
       initialInputState,
-      initialOutputState: initialOutputStateMap,
+      initialOutputState,
       initialTransientState,
       finalTransientState,
       onStateChange,
@@ -247,7 +243,7 @@ describe("useModelState", () => {
       result.current.saveToSelectedContainer();
     });
     expect(result.current.containers).toEqual(initContainerMap({
-      A: {inputState: {foo: false, bar: "updated"}, outputState: initialOutputState, simulationState: initialSimulationState, isSaved: true}}));
+      A: {inputState: {foo: false, bar: "updated"}, outputState: initialOutputState(), simulationState: initialSimulationState, isSaved: true}}));
     expect(result.current.isDirty).toEqual(false);
     expect(result.current.isSaved).toEqual(true);
     expect(logEvent).toHaveBeenCalledWith("save", {"data": {"containerId": "A", "inputState": {"bar": "updated", "foo": false}, "outputState": {"bam": 10}}, "includeState": true});
@@ -346,8 +342,9 @@ describe("useModelState", () => {
     const isValidExternalStateRetTrue = jest.fn(() => true);
 
     HookWrapper = () => useModelState<IModelInputState, IModelOutputState, IModelTransientState>({
+      initialContainerId: "A",
       initialInputState,
-      initialOutputState: initialOutputStateMap,
+      initialOutputState,
       initialTransientState,
       finalTransientState,
       onStateChange,
@@ -396,8 +393,9 @@ describe("useModelState", () => {
     const isValidExternalStateRetFalse = jest.fn(() => false);
 
     HookWrapper = () => useModelState<IModelInputState, IModelOutputState, IModelTransientState>({
+      initialContainerId: "A",
       initialInputState,
-      initialOutputState: initialOutputStateMap,
+      initialOutputState,
       initialTransientState,
       finalTransientState,
       onStateChange,


### PR DESCRIPTION
[[#177070719]](https://www.pivotaltracker.com/story/show/177070719)

In addition to fixing the inappropriate persistence of habitat features across containers, we also take this opportunity to eliminate some LeafPack-specific implementation details that had crept into the implementation of the `useModelState()` hook. Specifically, rather than accepting a map of initial output states (which requires that `useModelState()` know something about the containers required by LeafPack), the `initialInputState()` and `initialOutputState()` properties are now functions which return the required states on demand.

Finally, there is a unit test of the `useLeafPackModelState()` hook which tests that habitat features are preserved when they should be and not when they shouldn't be as well as that initial fish configurations can differ, etc.