### PR TITLE
Minor UI tweaks

### DIFF
--- a/src/components/control-panel/slider.scss
+++ b/src/components/control-panel/slider.scss
@@ -1,7 +1,7 @@
 @import "../vars.scss";
 
 .slider {
-  width: 90px;
+  width: 56px;
   height: 55px;
   margin: 5px;
 

--- a/src/components/notebook/chem-results.scss
+++ b/src/components/notebook/chem-results.scss
@@ -14,8 +14,13 @@
     background-color: $chemistry-blue-dark1;
 
     .category-label {
-      width: 50%;
       text-align: center;
+      &:first-child {
+        width: 56%;
+      }
+      &:last-child {
+        width: 44%;
+      }
     }
   }
 

--- a/src/components/notebook/chem-test.scss
+++ b/src/components/notebook/chem-test.scss
@@ -88,7 +88,13 @@
       font-family: "Lato", sans-serif;
       font-size: 14px;
       font-weight: bold;
+      text-align: left;
+      padding-left: 10px;
       cursor: pointer;
+
+      &.smallfont {
+        font-size: 12px;
+      }
 
       &:hover {
         background-color: $chemistry-blue-dark1;

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -112,7 +112,7 @@ export const ChemTest: React.FC<IProps> = (props) => {
               key={`${chemistryTest.type}-step-button-${index}`}
               onClick={() => handleStepButtonClick(step, index + 1)}
             >
-              {`Step ${index + 1}: ${step.label}`}
+              {`${t("CHEM.STEP")} ${index + 1}: ${step.label}`}
               { (index < stepsComplete) &&
                 <div className="step-check">
                   <CheckIcon

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -6,7 +6,7 @@ import { InputResult } from "./input-result";
 import CheckIcon from "../../assets/check-icon.svg";
 import { useCurrent } from "../../hooks/use-current";
 import {
-  ChemistryTest, ChemTestStep, StepType, ChemistryTestResult, ChemistryValues, IUpdateChemistryTestResult
+  ChemistryTest, ChemTestStep, StepType, ChemistryTestResult, ChemistryValues, IUpdateChemistryTestResult, ChemTestType
 } from "../../utils/chem-types";
 import t from "../../utils/translation/translate";
 
@@ -106,11 +106,13 @@ export const ChemTest: React.FC<IProps> = (props) => {
                                                 ((index === stepsComplete) &&
                                                   (index === testResult.current?.currentStep)),
                                       finished: index < stepsComplete,
-                                      running: index === testResult.current?.currentStep && index === stepsComplete})}
+                                      running: index === testResult.current?.currentStep && index === stepsComplete,
+                                      smallfont: chemistryTest.type === ChemTestType.airTemperature ||
+                                                chemistryTest.type === ChemTestType.waterTemperature})}
               key={`${chemistryTest.type}-step-button-${index}`}
               onClick={() => handleStepButtonClick(step, index + 1)}
             >
-              {step.label}
+              {`Step ${index + 1}: ${step.label}`}
               { (index < stepsComplete) &&
                 <div className="step-check">
                   <CheckIcon

--- a/src/components/notebook/chem-test.tsx
+++ b/src/components/notebook/chem-test.tsx
@@ -112,7 +112,7 @@ export const ChemTest: React.FC<IProps> = (props) => {
               key={`${chemistryTest.type}-step-button-${index}`}
               onClick={() => handleStepButtonClick(step, index + 1)}
             >
-              {`${t("CHEM.STEP")} ${index + 1}: ${step.label}`}
+              {`${t("CHEM.STEP", {vars: {step: `${index + 1}`}})}: ${step.label}`}
               { (index < stepsComplete) &&
                 <div className="step-check">
                   <CheckIcon

--- a/src/components/notebook/habitat-panel.tsx
+++ b/src/components/notebook/habitat-panel.tsx
@@ -44,7 +44,7 @@ export const HabitatPanel: React.FC<IProps> = (props) => {
                       onClick={() => onSelectFeature(feature, !featureSelections.has(feature))}
                       aria-label={habitatFeatures.find((f) => f.type === feature)?.label}
                     >
-                      <CheckIcon />
+                      <CheckIcon width={14} />
                     </button>
                     <div key={`feature-${fIndex}`}>{habitatFeatures.find((f) => f.type === feature)?.label}</div>
                   </div>

--- a/src/components/notebook/macro-animal-row.tsx
+++ b/src/components/notebook/macro-animal-row.tsx
@@ -10,7 +10,6 @@ import {
 
 import "./macro-panel.scss";
 
-// TODO: determine what this max is. Do we need a max for each animal type?
 const kMaxCritters = 60;
 const kMaxGraphWidth = 64;
 
@@ -80,13 +79,13 @@ export const MacroAnimalRow: React.FC<IProps> = (props) => {
           </>
       }
       <div className="name">{animal.label}</div>
-      <div className="count">{count}</div>
       <div className="graph" style={{borderColor: sensitivity?.graphColor}}>
         <div
           className="bar"
           style={{backgroundColor: sensitivity?.graphColor, width: kMaxGraphWidth * count / kMaxCritters}}
         />
       </div>
+      <div className="count">{count}</div>
       <div className="sensitivity">{sensitivity?.label}</div>
     </div>
   );

--- a/src/components/notebook/notebook.scss
+++ b/src/components/notebook/notebook.scss
@@ -39,8 +39,8 @@
     }
 
     .icon {
-      width: 24px;
-      height: 24px;
+      width: 18px;
+      height: 18px;
       margin-right: 5px;
     }
 

--- a/src/components/notebook/notebook.scss
+++ b/src/components/notebook/notebook.scss
@@ -39,8 +39,8 @@
     }
 
     .icon {
-      width: 18px;
-      height: 18px;
+      width: 20px;
+      height: 20px;
       margin-right: 5px;
     }
 

--- a/src/components/simulation/main-view-wrapper.scss
+++ b/src/components/simulation/main-view-wrapper.scss
@@ -46,4 +46,10 @@
       }
     }
   }
+
+  .sim-progress > div > div {
+    &:last-child {
+      background-color: $gray-dark;
+    }
+  }
 }

--- a/src/components/simulation/main-view-wrapper.tsx
+++ b/src/components/simulation/main-view-wrapper.tsx
@@ -33,6 +33,7 @@ export const MainViewWrapper: React.FC<IMainViewWrapperProps> = (props) => {
           currentTime={currentTime}
           maxTime={maxTime}
           currentTimeLabel={currentTimeLabel}
+          customClassName={"sim-progress"}
         />
       </div>
       {/* <div className="save-container">

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -7,8 +7,8 @@
   "BUTTON.PAUSE": "Pause",
   "BUTTON.CLOSE": "Close",
 
-  "LABEL.TIME_WEEK": "%{weeks} Week",
-  "LABEL.TIME_WEEKS": "%{weeks} Weeks",
+  "LABEL.TIME_WEEK": "Time: %{weeks} Week",
+  "LABEL.TIME_WEEKS": "Time: %{weeks} Weeks",
 
   "SUNNYDAY.LABEL": "Sunny Days",
   "SUNNYDAY.FEW": "Few",
@@ -124,8 +124,8 @@
   "CHEM.TEST": "Test",
   "CHEM.RESULT": "Result",
   "CHEM.WATER.RESULT": "Water Quality Result",
-  "CHEM.TEST.INCOMPLETE": "Test not yet complete",
-  "CHEM.TEST.UNSTARTED": "Test not yet run",
+  "CHEM.TEST.INCOMPLETE": "Test not complete",
+  "CHEM.TEST.UNSTARTED": "Test not run yet",
   "CHEM.EXCELLENT": "Excellent",
   "CHEM.GOOD": "Good",
   "CHEM.FAIR": "Fair",

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -127,7 +127,7 @@
   "CHEM.TEST.INCOMPLETE": "Test not complete",
   "CHEM.TEST.UNSTARTED": "Test not run yet",
   "CHEM.EXCELLENT": "Excellent",
-  "CHEM.STEP": "Step",
+  "CHEM.STEP": "Step %{step}",
   "CHEM.GOOD": "Good",
   "CHEM.FAIR": "Fair",
   "CHEM.POOR": "Poor",

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -61,7 +61,7 @@
   "PTI.RATING.LEVEL2.RANGE": "11 - 16",
   "PTI.RATING.LEVEL3.RANGE": "10 or less",
 
-  "HABITAT.SKETCH": "Sketch",
+  "HABITAT.SKETCH": "Stream Sketch",
   "HABITAT.STREAMHABITATS": "Stream Habitats",
   "HABITAT.BANKS": "Stream Banks",
   "HABITAT.INSTREAM": "In Stream",

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -127,6 +127,7 @@
   "CHEM.TEST.INCOMPLETE": "Test not complete",
   "CHEM.TEST.UNSTARTED": "Test not run yet",
   "CHEM.EXCELLENT": "Excellent",
+  "CHEM.STEP": "Step",
   "CHEM.GOOD": "Good",
   "CHEM.FAIR": "Fair",
   "CHEM.POOR": "Poor",

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -127,7 +127,7 @@
   "CHEM.TEST.INCOMPLETE": "Prueba no completada",
   "CHEM.TEST.UNSTARTED": "Prueba aún no ejecutada",
   "CHEM.EXCELLENT": "Excelente",
-  "CHEM.STEP": "Paso",
+  "CHEM.STEP": "Paso %{step}",
   "CHEM.GOOD": "Buena",
   "CHEM.FAIR": "Pasable",
   "CHEM.POOR": "Malo",

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -7,8 +7,8 @@
   "BUTTON.PAUSE": "Pausa",
   "BUTTON.CLOSE": "Cerrar",
 
-  "LABEL.TIME_WEEK": "%{weeks} Semana",
-  "LABEL.TIME_WEEKS": "%{weeks} Semanas",
+  "LABEL.TIME_WEEK": "Tiempo: %{weeks} Semana",
+  "LABEL.TIME_WEEKS": "Tiempo: %{weeks} Semanas",
 
   "SUNNYDAY.LABEL": "Días Soleados",
   "SUNNYDAY.FEW": "Pocas",

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -61,7 +61,7 @@
   "PTI.RATING.LEVEL2.RANGE": "11 - 16",
   "PTI.RATING.LEVEL3.RANGE": "10 o menos",
 
-  "HABITAT.SKETCH": "Bosquejo",
+  "HABITAT.SKETCH": "Bosquejo de arroyo",
   "HABITAT.STREAMHABITATS": "Hábitats de arroyos",
   "HABITAT.BANKS": "Bancos de arroyos",
   "HABITAT.INSTREAM": "En corriente",

--- a/src/utils/translation/lang/es.json
+++ b/src/utils/translation/lang/es.json
@@ -127,6 +127,7 @@
   "CHEM.TEST.INCOMPLETE": "Prueba no completada",
   "CHEM.TEST.UNSTARTED": "Prueba aún no ejecutada",
   "CHEM.EXCELLENT": "Excelente",
+  "CHEM.STEP": "Paso",
   "CHEM.GOOD": "Buena",
   "CHEM.FAIR": "Pasable",
   "CHEM.POOR": "Malo",


### PR DESCRIPTION
This PR includes a series of UI fixes to bring the app in line with the UI spec.  Changes include:
- change habitat feature header from "Sketch" to "Stream Sketch"
- fix size of habitat feature checkbox
- fix size of notebook header icons
- change progress bar text to include label prefix "Time:"
- change progress bar color from green to black
- fix sunny day slider width
- swap position of progress bar and taxa count in macro notebook
- change chem lab text to "test not run yet"
- fix test results header text spacing
- add step number to chem lab test buttons, fix size and alignment