### PR TITLE
Update @concord-consortium/react-components; add <ControlPanel/> unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules
 npm-error.log
 .DS_Store
 .nyc_output
+.yalc
+yalc.lock
 
 # Editors
 .idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1283,11 +1283,11 @@
       }
     },
     "@concord-consortium/react-components": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/react-components/-/react-components-0.5.0.tgz",
-      "integrity": "sha512-X6YBRw+tUAe+5ZACHTUFbYtEOVj+IzRy9delmEujb6gL5CxuBRcwyjN5pwOxwDHsRyLEk9JyNNvZjuHmjM2zGA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/react-components/-/react-components-0.6.0.tgz",
+      "integrity": "sha512-qAXEqxzDZPL7Az1IntUXimzYhE7b/CSGon6OJouBSXoU3I2spjWzduykf/t9oi5ziD3XT/t4S2JbhoS5Hj/0mg==",
       "requires": {
-        "styled-components": "^4.4.0"
+        "styled-components": "^5.2.1"
       }
     },
     "@cypress/browserify-preprocessor": {
@@ -1560,6 +1560,11 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
     },
     "@emotion/unitless": {
       "version": "0.7.5",
@@ -6387,20 +6392,13 @@
       "dev": true
     },
     "css-to-react-native": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
-      "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^3.3.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
-        }
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "css-tree": {
@@ -10289,11 +10287,6 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
-    "is-what": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.12.0.tgz",
-      "integrity": "sha512-2ilQz5/f/o9V7WRWJQmpFYNmQFZ9iM+OXRonZKcYgTkCzjb949Vi4h282PD1UfmgHk666rcWonbRJ++KI41VGw=="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -12975,11 +12968,6 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
-    "memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
-    },
     "memory-fs": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
@@ -13071,14 +13059,6 @@
             "read-pkg": "^1.0.0"
           }
         }
-      }
-    },
-    "merge-anything": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.4.tgz",
-      "integrity": "sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==",
-      "requires": {
-        "is-what": "^3.3.1"
       }
     },
     "merge-descriptors": {
@@ -14743,8 +14723,7 @@
     "postcss-value-parser": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
-      "dev": true
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -16147,6 +16126,11 @@
         "kind-of": "^6.0.2"
       }
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shasum": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
@@ -17043,34 +17027,21 @@
       }
     },
     "styled-components": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.1.tgz",
-      "integrity": "sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.1.tgz",
+      "integrity": "sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@emotion/is-prop-valid": "^0.8.1",
-        "@emotion/unitless": "^0.7.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
         "babel-plugin-styled-components": ">= 1",
-        "css-to-react-native": "^2.2.2",
-        "memoize-one": "^5.0.0",
-        "merge-anything": "^2.2.4",
-        "prop-types": "^15.5.4",
-        "react-is": "^16.6.0",
-        "stylis": "^3.5.0",
-        "stylis-rule-sheet": "^0.0.10",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
       }
-    },
-    "stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
-    },
-    "stylis-rule-sheet": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
     "subarg": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   },
   "dependencies": {
     "@concord-consortium/lara-interactive-api": "^1.0.2",
-    "@concord-consortium/react-components": "^0.5.0",
+    "@concord-consortium/react-components": "^0.6.0",
     "@material-ui/core": "^4.11.3",
     "@testing-library/react": "^11.2.5",
     "@types/classnames": "^2.2.11",

--- a/src/components/control-panel/control-panel.test.tsx
+++ b/src/components/control-panel/control-panel.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ControlPanel } from "./control-panel";
+import { EnvironmentType } from "../../utils/environment";
+
+function hasChildContainingText(parent: Element, text: string, tag = "div") {
+  // https://stackoverflow.com/a/3813334
+  const children = parent.getElementsByTagName(tag);
+  return !!Array.from(children).find(child => child?.textContent?.includes(text));
+}
+
+describe("ControlPanel component", () => {
+  const startSim = jest.fn();
+  const pauseSim = jest.fn();
+  const rewindSim = jest.fn();
+  const changeSunnyDaysSlider = jest.fn();
+  const changeEnvironment = jest.fn();
+
+  it("renders initial state", () => {
+    const { container } = render(
+      <ControlPanel
+        isRunning={false} isPaused={false} isFinished={false} inputControlsDisabled={false}
+        onStartSim={startSim} onPauseSim={pauseSim} onRewindSim={rewindSim}
+        sunnyDayFequency={0} onChangeSunnyDaySlider={changeSunnyDaysSlider}
+        environment={EnvironmentType.environment1} onChangeEnvironment={changeEnvironment}
+      />);
+
+    const sunnyDaySliderWrapper = screen.getByTestId("sunny-day-slider");
+    const sunnyDaySlider = sunnyDaySliderWrapper?.querySelector(".slider");
+    expect(sunnyDaySlider).not.toHaveClass("disabled");
+
+    const vcrButtons = container.querySelectorAll(".vcr-button");
+    vcrButtons.forEach(button => {
+      if (hasChildContainingText(button, "Rewind")) {
+        expect(button).toBeDisabled();
+      }
+      else if (hasChildContainingText(button, "Start")) {
+        expect(button).toBeEnabled();
+      }
+      else {
+        expect("Unidentified button encountered").toBe(true);
+      }
+    });
+  });
+
+  it("renders running state", () => {
+    const { container } = render(
+      <ControlPanel
+        isRunning={true} isPaused={false} isFinished={false} inputControlsDisabled={true}
+        onStartSim={startSim} onPauseSim={pauseSim} onRewindSim={rewindSim}
+        sunnyDayFequency={0} onChangeSunnyDaySlider={changeSunnyDaysSlider}
+        environment={EnvironmentType.environment1} onChangeEnvironment={changeEnvironment}
+      />);
+
+    const sunnyDaySliderWrapper = screen.getByTestId("sunny-day-slider");
+    const sunnyDaySlider = sunnyDaySliderWrapper?.querySelector(".slider");
+    expect(sunnyDaySlider).toHaveClass("disabled");
+
+    const vcrButtons = container.querySelectorAll(".vcr-button");
+    vcrButtons.forEach(button => {
+      if (hasChildContainingText(button, "Rewind")) {
+        expect(button).toBeEnabled();
+      }
+      else if (hasChildContainingText(button, "Pause")) {
+        expect(button).toBeEnabled();
+      }
+      else {
+        expect("Unidentified button encountered").toBe(true);
+      }
+    });
+  });
+
+  it("renders paused state", () => {
+    const { container } = render(
+      <ControlPanel
+        isRunning={true} isPaused={true} isFinished={false} inputControlsDisabled={true}
+        onStartSim={startSim} onPauseSim={pauseSim} onRewindSim={rewindSim}
+        sunnyDayFequency={0} onChangeSunnyDaySlider={changeSunnyDaysSlider}
+        environment={EnvironmentType.environment1} onChangeEnvironment={changeEnvironment}
+      />);
+
+    const sunnyDaySliderWrapper = screen.getByTestId("sunny-day-slider");
+    const sunnyDaySlider = sunnyDaySliderWrapper?.querySelector(".slider");
+    expect(sunnyDaySlider).toHaveClass("disabled");
+
+    const vcrButtons = container.querySelectorAll(".vcr-button");
+    vcrButtons.forEach(button => {
+      if (hasChildContainingText(button, "Rewind")) {
+        expect(button).toBeEnabled();
+      }
+      else if (hasChildContainingText(button, "Start")) {
+        expect(button).toBeEnabled();
+      }
+      else {
+        expect("Unidentified button encountered").toBe(true);
+      }
+    });
+  });
+
+  it("renders finished state", () => {
+    const { container } = render(
+      <ControlPanel
+        isRunning={false} isPaused={false} isFinished={true} inputControlsDisabled={true}
+        onStartSim={startSim} onPauseSim={pauseSim} onRewindSim={rewindSim}
+        sunnyDayFequency={0} onChangeSunnyDaySlider={changeSunnyDaysSlider}
+        environment={EnvironmentType.environment1} onChangeEnvironment={changeEnvironment}
+      />);
+
+    const sunnyDaySliderWrapper = screen.getByTestId("sunny-day-slider");
+    const sunnyDaySlider = sunnyDaySliderWrapper?.querySelector(".slider");
+    expect(sunnyDaySlider).toHaveClass("disabled");
+
+    const vcrButtons = container.querySelectorAll(".vcr-button");
+    vcrButtons.forEach(button => {
+      if (hasChildContainingText(button, "Rewind")) {
+        expect(button).toBeEnabled();
+      }
+      else if (hasChildContainingText(button, "Start")) {
+        expect(button).toBeDisabled();
+      }
+      else {
+        expect("Unidentified button encountered").toBe(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Previously, components that used components from `@concord-components/react-components` weren't unit-testable due to the fact that `@concord-components/react-components` was published as es6 modules but jest doesn't yet support es6 modules. Therefore, `@concord-components/react-components` was updated to publish as a commonjs module, and this PR updates to the newer version and adds a unit test for the `<ControlPanel/>` component.