### PR TITLE
Tweaks to <SimulationAnimation> component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3387,6 +3387,12 @@
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
     },
+    "@types/string-hash": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/string-hash/-/string-hash-1.1.1.tgz",
+      "integrity": "sha512-ijt3zdHi2DmZxQpQTmozXszzDo78V4R3EdvX0jFMfnMH2ZzQSmCbaWOMPGXFUYSzSIdStv78HDjg32m5dxc+tA==",
+      "dev": true
+    },
     "@types/tapable": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
@@ -16685,6 +16691,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-length": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/react-dom": "^17.0.1",
     "@types/react-modal": "^3.12.0",
     "@types/react-tabs": "^2.3.2",
+    "@types/string-hash": "^1.1.1",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "autoprefixer": "^10.2.4",
@@ -142,6 +143,7 @@
     "react-modal": "^3.12.1",
     "react-tabs": "^3.2.0",
     "react-transition-group": "^4.4.1",
+    "string-hash": "^1.1.3",
     "ts-polyfill": "^3.8.2"
   }
 }

--- a/src/components/simulation/simulation-animation.scss
+++ b/src/components/simulation/simulation-animation.scss
@@ -3,6 +3,4 @@
 .simulation-animation {
   position: absolute;
   width: 30px;
-  left: 100px;
-  top: 100px;
 }

--- a/src/components/simulation/simulation-animation.tsx
+++ b/src/components/simulation/simulation-animation.tsx
@@ -5,28 +5,38 @@ import { getRandomInteger } from "../../utils/math-utils";
 
 import "./simulation-animation.scss";
 
-const kFrameInterval = 133;
+const kDefaultInterval = 133;
 
 interface IProps {
-  animation: SimAnimation,
+  animation: SimAnimation;
+  interval?: number;
 }
 
-export const SimulationAnimation: React.FC<IProps> = (props) => {
-  const { animation } = props;
+export const SimulationAnimation: React.FC<IProps> = ({ animation, interval = kDefaultInterval }) => {
   const maxFrame = animation.frames.length;
   const [currentFrame, setCurrentFrame] = useState(getRandomInteger(0, maxFrame - 1));
+
   useInterval(() => {
     setCurrentFrame(frame => (frame + 1) % maxFrame);
-  }, kFrameInterval);
+  }, interval);
 
-
-  const transformation = `rotate(${animation.rotation}deg) scaleX(${animation.xScale}) scaleY(${animation.yScale})`;
+  const uniqueUrls = new Set(animation.frames);
+  const transform = `rotate(${animation.rotation}deg) scaleX(${animation.xScale}) scaleY(${animation.yScale})`;
   return (
-    <img
-      src={animation.frames[currentFrame]}
-      className={"simulation-animation"}
-      style={{ top: animation.top, left: animation.left, transform: transformation }}
-      alt={animation.altText}
-    />
+    <>
+      {Array.from(uniqueUrls).map((url, index) => {
+        const visibleUrl = animation.frames[currentFrame];
+        const visibility = url === visibleUrl ? "visible" : "hidden";
+        return (
+          <img
+            key={`unique-url-${index}`}
+            src={url}
+            className="simulation-animation"
+            style={{ top: animation.top, left: animation.left, transform, visibility }}
+            alt={animation.altText}
+          />
+        );
+      })}
+    </>
   );
 };

--- a/src/components/simulation/simulation-animation.tsx
+++ b/src/components/simulation/simulation-animation.tsx
@@ -19,6 +19,7 @@ export const SimulationAnimation: React.FC<IProps> = ({ animation, interval = kD
 
   const opacity = Math.round(1000 * useFadeIn(fadeIn)) / 1000;
 
+  // hash the urls because blob urls can be multiple KB
   const uniqueUrls = useHashedStrings(animation.frames);
   const transform = `rotate(${animation.rotation}deg) scaleX(${animation.xScale}) scaleY(${animation.yScale})`;
   return (

--- a/src/components/simulation/simulation-view.scss
+++ b/src/components/simulation/simulation-view.scss
@@ -14,18 +14,3 @@
   }
 
 }
-
-.animation-item-enter {
-  opacity: 0;
-}
-.animation-item-enter-active {
-  opacity: 1;
-  transition: opacity 3667ms ease-in;
-}
-.animation-item-exit {
-  opacity: 1;
-}
-.animation-item-exit-active {
-  opacity: 0;
-  transition: opacity 100ms ease-in;
-}

--- a/src/components/simulation/simulation-view.tsx
+++ b/src/components/simulation/simulation-view.tsx
@@ -1,11 +1,10 @@
-import React from "react";
+import React, { useRef } from "react";
 import { LeafPack } from "./leaf-pack";
 import { SimulationAnimation } from "./simulation-animation";
 import { EnvironmentType, Environments, Environment } from "../../utils/environment";
 import {
   LeafPackConfigurations, LeafPackState, simAnimationConfigurations, SimAnimation, FishAmountType, SimAnimationType,
 } from "../../utils/sim-utils";
-import { TransitionGroup, CSSTransition } from "react-transition-group";
 
 import "./simulation-view.scss";
 
@@ -39,6 +38,7 @@ export const SimulationView: React.FC<IProps> = (props) => {
   } else if (fish === FishAmountType.lots) {
     fishCount = kFishCountLots;
   }
+  const initialFishCount = useRef(fishCount);
   const fishAnimationConfig = simAnimationConfigurations.find((aniConfig) => aniConfig.type === SimAnimationType.fish);
   const fishAnimations: SimAnimation[] = [];
   fishAnimationConfig?.layouts.filter((l) => l.environment === environment).forEach((layout, index) => {
@@ -84,21 +84,16 @@ export const SimulationView: React.FC<IProps> = (props) => {
         isFinished={isFinished}
         isRunning={isRunning}
       />
-      <TransitionGroup>
-        { fishAnimations.map((animation, index) =>
-            <CSSTransition
-              key={`fish-transition-${environment}-${index}`}
-              timeout={isRunning ? kSimulationOneWeekPeriodInMilliseconds : 0}
-              classNames="animation-item"
-            >
-              <SimulationAnimation
-                animation={animation}
-                key={`fish-animation-${environment}-${index}`}
-              />
-            </CSSTransition>
-          )
-        }
-      </TransitionGroup>
+      { fishAnimations.map((animation, index) =>
+          <SimulationAnimation
+            animation={animation}
+            fadeIn={isFinished || (index < initialFishCount.current)
+                      ? 0
+                      : kSimulationOneWeekPeriodInMilliseconds}
+            key={`fish-animation-${environment}-${index}`}
+          />
+        )
+      }
       { simAnimations.map((animation, index) =>
           <SimulationAnimation
             animation={animation}

--- a/src/hooks/use-fade-in.ts
+++ b/src/hooks/use-fade-in.ts
@@ -1,0 +1,6 @@
+import { useRef } from "react";
+
+export const useFadeIn = (duration?: number) => {
+  const t0 = useRef(performance.now());
+  return duration ? (performance.now() - t0.current) / duration : 1;
+};

--- a/src/hooks/use-frame-loop.ts
+++ b/src/hooks/use-frame-loop.ts
@@ -1,0 +1,14 @@
+import { useState } from "react";
+import { getRandomInteger } from "../utils/math-utils";
+import { useInterval } from "./use-interval";
+
+export const useFrameLoop = (frameCount: number, frameInterval: number, start?: number) => {
+  const firstFrame = start != null ? start : getRandomInteger(0, frameCount - 1);
+  const [currentFrame, setCurrentFrame] = useState(firstFrame);
+
+  useInterval(() => {
+    setCurrentFrame(frame => (frame + 1) % frameCount);
+  }, frameInterval);
+
+  return currentFrame;
+};

--- a/src/hooks/use-hashed-strings.test.ts
+++ b/src/hooks/use-hashed-strings.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { hashString, useHashedStrings } from "./use-hashed-strings";
+
+describe("useHashedStrings", () => {
+
+  test("handles an empty array", () => {
+    const { result } = renderHook(() => useHashedStrings([]));
+    expect(Object.keys(result.current).length).toBe(0);
+  });
+
+  test("handles unique strings", () => {
+    const { result } = renderHook(() =>
+      useHashedStrings(["string1", "string2", "string3"]));
+    expect(Object.keys(result.current).length).toBe(3);
+  });
+
+  test("handles duplicate strings", () => {
+    const { result } = renderHook(() =>
+      useHashedStrings(["string1", "string2", "string3", "string1", "string2", "string3"]));
+    expect(Object.keys(result.current).length).toBe(3);
+  });
+
+  test("provides access to hash function", () => {
+    const str = "string1";
+    const { result } = renderHook(() =>
+      useHashedStrings([str]));
+    const key = hashString(str);
+    expect(result.current[key]).toBe(str);
+  });
+
+});

--- a/src/hooks/use-hashed-strings.ts
+++ b/src/hooks/use-hashed-strings.ts
@@ -1,0 +1,22 @@
+import hash from "string-hash";
+import { useEffect, useRef } from "react";
+
+export const hashString = (str: string) => {
+  return hash(str);
+};
+
+export const hashStrings = (strings: string[]) => {
+  const map: Record<string, string> = {};
+  strings.forEach(str => map[hash(str)] = str);
+  return map;
+};
+
+export const useHashedStrings = (strings: string[]) => {
+  const hashedStrs = useRef<Record<string, string>>(hashStrings(strings));
+
+  useEffect(() => {
+    hashedStrs.current = hashStrings(strings);
+  }, [strings, hashedStrs]);
+
+  return hashedStrs.current;
+};

--- a/src/utils/sim-utils.ts
+++ b/src/utils/sim-utils.ts
@@ -481,7 +481,7 @@ export const simAnimationConfigurations: SimAnimationConfiguration[] = [
 ];
 
 export interface SimAnimation {
-  frames: any[],
+  frames: string[], // suitable for the src of an <img>
   left: number;
   top: number;
   xScale: number;


### PR DESCRIPTION
Well, _that_ was more of an odyssey than I expected. The original issue reported by @scytacki was that in its steady-state, when viewed in a browser with caching disabled (not an expected end-user situation), leaf-pack continuously loads the images used for animation (i.e. the network panel continues to show activity for each animation frame). It was hypothesized that this might lead to performance issues as well, e.g. higher CPU usage.

The relatively simple fix which was straightforward to implement was to render all frames into the DOM and use CSS `visibility` to control which frame is visible rather than rendering only a single frame at a time into the DOM as we had been before. In a parallel universe that makes sense this would have been the end of the story. In _this_ universe, however, it was just my entree into the rabbit hole.

With the fish animations, unlike any of the other animations, the animation occurs within an `opacity` transition, because the fish fade in gradually while they're animating/swimming. This `opacity` transition was handled with ReactTransitionGroup's `<TransitionGroup>` and `<CSSTransition>` components, which under the hood make use of a CSS transition on `opacity`. After making the change to control frame visibility through CSS `visibility` rather than through presence/absence in the DOM, there was obvious and distracting flashing that occurred. Looking closely it was apparent that the images were flickering between the properly translucent state consistent with their `opacity` and their final state somewhat randomly. After beating my head against this for several hours trying to figure out what I was doing wrong, I eventually came to the conclusion that browsers apparently can't handle simultaneously changing CSS properties while transitioning another CSS property (e.g. `opacity`). I tried using position (`left`, `right`) to control visibility instead of `visibility` but the effect was the same. This [issue](https://stackoverflow.com/questions/24465619/opacity-change-during-a-transition-flickers-in-safari) was raised on Stack Overflow for Safari years ago (by none other than React's Dan Abramov) but now appears to affect Chrome and Firefox on Mac and Windows as well.

Eventually, it occurred to me that I could eliminate the `<TransitionGroup>` and `<CSSTransition>` components and just handle the `opacity` inside the animation component itself with a timer. Now the `opacity` is handled by the `<SimulationAnimation>` component itself rather than relying on a CSS transition applied by the parent in the case of the fish animation. In theory this could lead to a user-visible difference in the case of slow animations with longer durations on each frame, in which case the previous implementation would continue to change the `opacity` on each frame while the new implementation only changes the opacity on frame transitions, but in most real-world scenarios this difference is unlikely to be noticeable. Phew!