### PR TITLE
177346919 abundance counts

### DIFF
--- a/src/components/notebook/macro-animal-row.tsx
+++ b/src/components/notebook/macro-animal-row.tsx
@@ -10,7 +10,7 @@ import {
 
 import "./macro-panel.scss";
 
-const kMaxCritters = 60;
+const kMaxCritters = 72; // 20% more than the max possible abundance
 const kMaxGraphWidth = 64;
 
 const errorX = (sensitivity: SensitivityType, errorClass: string) => {

--- a/src/components/notebook/macro-animal-row.tsx
+++ b/src/components/notebook/macro-animal-row.tsx
@@ -10,7 +10,9 @@ import {
 
 import "./macro-panel.scss";
 
-const kMaxCritters = 72; // 20% more than the max possible abundance
+const kMaxTaxa = 60;
+const kLowSunAbundanceFactor = 1.2;
+const kMaxCritters = Math.round(kMaxTaxa * kLowSunAbundanceFactor);
 const kMaxGraphWidth = 64;
 
 const errorX = (sensitivity: SensitivityType, errorClass: string) => {

--- a/src/hooks/use-leaf-model-state.ts
+++ b/src/hooks/use-leaf-model-state.ts
@@ -79,7 +79,7 @@ export const useLeafModelState = (props: IProps) => {
   return {
     model: modelsRef.current[modelState.selectedContainerId],
     resetModel: () => {
-      modelsRef.current[modelState.selectedContainerId] = new Model(initialInputState(modelState.selectedContainerId));
+      modelsRef.current[modelState.selectedContainerId] = new Model(modelState.inputState);
     },
     ...modelState
   };

--- a/src/model.ts
+++ b/src/model.ts
@@ -24,10 +24,10 @@ export class Model {
         ? animal.abundance[this.environment].notSunny
         : animal.abundance[this.environment].sunny;
       const animalAbundance = getRandomInteger(abundanceRange.min, abundanceRange.max);
-      // TODO: for now adjust each abundance number by 30% if it is less sunny, ultimately this should be in abundanceRange
-      const animalAbundanceAdjusted = Math.floor(this.sunnyDayFequency === 0 ? animalAbundance : animalAbundance * .7);
-      for (let x = 0; x < animalAbundance; x++) {
-        // TODO: for now spread spawn over max time, but this should be more realistic
+      // increase each abundance number by 20% if it is less sunny
+      // ideally this should be in abundanceRange, but we never received taxa specific details
+      const animalAbundanceAdjusted = Math.floor(this.sunnyDayFequency === 0 ? animalAbundance * 1.2 : animalAbundance);
+      for (let x = 0; x < animalAbundanceAdjusted; x++) {
         const spawnOffset = 60;
         const spawnDelta = Math.floor((kMaxSteps - spawnOffset) / animalAbundanceAdjusted);
         const animalInstance: AnimalInstance = { type: animal.type,


### PR DESCRIPTION
This PR adds two small improvements:
- update the sim abundances to increase abundance counts by 20% when we have few sunny days
- use the model input state, not initial state, when resetting the model.  This fixes a handful of issues where we were not preserving the sunny day slider state when `resetModel` was called.